### PR TITLE
Fix MarketService DTO mapping

### DIFF
--- a/src/main/java/com/cwdarmm/service/MarketService.java
+++ b/src/main/java/com/cwdarmm/service/MarketService.java
@@ -52,6 +52,8 @@ public class MarketService {
                 .accountSize(e.getAccountSize())
                 .riskA(e.getRiskA())
                 .riskB(e.getRiskB())
+                .riskFinalHouse(e.getRiskFinalHouse() == null ? 0 : e.getRiskFinalHouse())
+                .riskFinalLunch(e.getRiskFinalLunch() == null ? 0 : e.getRiskFinalLunch())
                 .build();
 
     }


### PR DESCRIPTION
## Summary
- map `riskFinalHouse` and `riskFinalLunch` when converting `MarketEntity` to `MarketDTO`

## Testing
- ❌ `mvn -q -DskipTests package` *(failed: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879ca5c9a24832d8cb2e2032b32e515