### PR TITLE
Add initial risk metrics skeleton

### DIFF
--- a/docs/next_steps.md
+++ b/docs/next_steps.md
@@ -1,0 +1,8 @@
+# Next Steps
+
+- Implementar la fórmula de **expectativa**:
+  expectativa = promedio de ganancias × probabilidad de ganar 
+  – promedio de pérdidas × (1 − probabilidad de ganar).
+- Calcular el **drawdown** como la mayor caída pico–valle de la curva de capital.
+- Calcular el **riesgo de ruina** usando probabilidad de acierto, payoff y riesgo por operación. Ver fórmulas detalladas en el PDF original.
+- Generar ejemplos de salida XML y AHK similares a los métodos de `ExportService`.

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,13 @@
             <artifactId>hibernate-community-dialects</artifactId>
         </dependency>
 
+        <!-- Dependencias para pruebas -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
 
     </dependencies>
 

--- a/src/main/java/com/cwdarmm/service/RiskMetricsService.java
+++ b/src/main/java/com/cwdarmm/service/RiskMetricsService.java
@@ -1,0 +1,36 @@
+package com.cwdarmm.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Servicio con cálculos estadísticos básicos para el manejo de riesgo.
+ */
+@Service
+public class RiskMetricsService {
+
+    /**
+     * Calcula la expectativa del sistema.
+     * TODO: expectativa = promedio de ganancias × probabilidad – pérdidas × (1 − probabilidad)
+     */
+    public double calculateExpectancy(List<Double> trades) {
+        return 0.0; // pendiente de implementar
+    }
+
+    /**
+     * Calcula el drawdown máximo de la curva de capital.
+     * TODO: drawdown = caída máxima desde un pico a un valle de la curva
+     */
+    public double calculateDrawdown(List<Double> history) {
+        return 0.0; // pendiente de implementar
+    }
+
+    /**
+     * Calcula el riesgo de ruina.
+     * TODO: fórmula basada en probabilidad de ganar, payoff y número de operaciones
+     */
+    public double calculateRiskOfRuin(double winRate, double payoff, int trades) {
+        return 0.0; // pendiente de implementar
+    }
+}

--- a/src/main/java/com/cwdarmm/service/RiskService.java
+++ b/src/main/java/com/cwdarmm/service/RiskService.java
@@ -16,6 +16,8 @@ public class RiskService {
     // si necesitas leer definiciones de mercado, inyecta MarketDefinitionRepository u otro
     // private final MarketDefinitionRepository repo;
 
+    private final RiskMetricsService riskMetricsService;
+
     public List<String> listAccounts() {
         return List.of("ACC1","ACC2","ACC3");
     }
@@ -31,7 +33,7 @@ public class RiskService {
      */
     public List<RiskResultDTO> calculate(RiskInputDTO in) {
         // Ejemplo: simulamos N trades (aquí 1 inicial + 5 siguientes)
-        return IntStream.rangeClosed(0, 5)
+        List<RiskResultDTO> list = IntStream.rangeClosed(0, 5)
                 .mapToObj(i -> {
                     RiskResultDTO r = new RiskResultDTO();
                     r.setTradeNumber(i);
@@ -44,5 +46,14 @@ public class RiskService {
                     return r;
                 })
                 .collect(Collectors.toList());
+
+        // Invocar cálculos básicos y mostrar en log
+        var sampleTrades = List.of(100.0, -50.0, 80.0);
+        double expectancy = riskMetricsService.calculateExpectancy(sampleTrades);
+        double dd = riskMetricsService.calculateDrawdown(sampleTrades);
+        double ror = riskMetricsService.calculateRiskOfRuin(0.5, 1.5, sampleTrades.size());
+        System.out.println("Risk metrics -> expectancy=" + expectancy + ", drawdown=" + dd + ", riskOfRuin=" + ror);
+
+        return list;
     }
 }

--- a/src/test/java/com/cwdarmm/service/RiskMetricsServiceTest.java
+++ b/src/test/java/com/cwdarmm/service/RiskMetricsServiceTest.java
@@ -1,0 +1,18 @@
+package com.cwdarmm.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class RiskMetricsServiceTest {
+
+    private final RiskMetricsService service = new RiskMetricsService();
+
+    @Test
+    void methodsShouldNotThrow() {
+        Assertions.assertDoesNotThrow(() -> service.calculateExpectancy(List.of(1.0, -1.0)));
+        Assertions.assertDoesNotThrow(() -> service.calculateDrawdown(List.of(100.0, 95.0, 105.0)));
+        Assertions.assertDoesNotThrow(() -> service.calculateRiskOfRuin(0.5, 1.5, 10));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `RiskMetricsService` with placeholders for calculations
- wire the new service into `RiskService`
- call risk metric methods with sample data and log output
- add minimal unit test
- document next implementation steps
- include test dependency in `pom.xml`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6879cf5e6b14832da19748364694f448