### PR TITLE
Improve CSV export and risk analysis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
             <artifactId>commons-math3</artifactId>
             <version>3.6.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.10.0</version>
+        </dependency>
 
         <!-- Lombok -->
         <dependency>

--- a/src/main/java/com/cwdarmm/service/OutputService.java
+++ b/src/main/java/com/cwdarmm/service/OutputService.java
@@ -3,6 +3,8 @@ package com.cwdarmm.service;
 
 import com.cwdarmm.model.dto.RiskResultDTO;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -15,21 +17,25 @@ import java.util.List;
 @RequiredArgsConstructor
 public class  OutputService {
 
-    private static final String HEADER = "TradeNumber,WL,Account,MarketData,AccountSize,RiskKellyA,RiskKellyB";
-
+    private static final String[] HEADERS = {
+            "TradeNumber", "WL", "Account", "MarketData",
+            "AccountSize", "RiskKellyA", "RiskKellyB"
+    };
 
     public void exportRiskResultsToCsv(List<RiskResultDTO> results, Path outputFile) throws IOException {
-        var sb = new StringBuilder();
-        sb.append(HEADER).append("\n");
-        for (RiskResultDTO r : results) {
-            sb.append(r.getTradeNumber()).append(',')
-                    .append(r.getWl()).append(',')
-                    .append(r.getAccount()).append(',')
-                    .append(r.getMarketData()).append(',')
-                    .append(r.getAccountSize()).append(',')
-                    .append(r.getRiskKellyA()).append(',')
-                    .append(r.getRiskKellyB()).append('\n');
+        try (var writer = Files.newBufferedWriter(outputFile, StandardCharsets.UTF_8);
+             var printer = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader(HEADERS))) {
+            for (RiskResultDTO r : results) {
+                printer.printRecord(
+                        r.getTradeNumber(),
+                        r.getWl(),
+                        r.getAccount(),
+                        r.getMarketData(),
+                        r.getAccountSize(),
+                        r.getRiskKellyA(),
+                        r.getRiskKellyB()
+                );
+            }
         }
-        Files.writeString(outputFile, sb.toString(), StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
+++ b/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
@@ -36,16 +36,16 @@ public class RiskAnalysisService {
         }
 
         // b) Cálculo de “Optimal Contracts”
-        int tradeNum = in.isFirstTrade() ? 1 : 1;
+        int tradeNum = 1;
         // Si quieres recuperar el último número de la tabla anterior,
         // hazlo en el controller antes de llamar al servicio.
 
         // Fórmula genérica (ajusta según tu Excel)
-        Integer tick = in.isHouse()
+        int tick = in.isHouse()
                 ? in.getTicksSl1()
                 : in.getTicksSl2();
         BigDecimal contracts = in.getAccountSize()
-                .multiply(new BigDecimal(tick))
+                .multiply(BigDecimal.valueOf(tick))
                 .divideToIntegralValue(
                         BigDecimal.valueOf(in.getStopLossSize())
                 );


### PR DESCRIPTION
## Summary
- use Apache Commons CSV for safer export of risk results
- fix constant trade number logic
- clean BigDecimal conversions
- add Apache Commons CSV dependency

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881d5276658832d939eba3c695c0019