### PR TITLE
Enable BD market calculations

### DIFF
--- a/src/main/java/com/cwdarmm/controller/RiskConfigController.java
+++ b/src/main/java/com/cwdarmm/controller/RiskConfigController.java
@@ -258,6 +258,8 @@ public class RiskConfigController {
                 .lunch(chkLunch.isSelected())
                 .win(chkWin.isSelected())
                 .loss(chkLoss.isSelected())
+                .riskPctA(marketContext != null ? BigDecimal.valueOf(marketContext.getRiskA()) : null)
+                .riskPctB(marketContext != null ? BigDecimal.valueOf(marketContext.getRiskB()) : null)
                 .build();
     }
 }

--- a/src/main/java/com/cwdarmm/repository/BdMarketRepository.java
+++ b/src/main/java/com/cwdarmm/repository/BdMarketRepository.java
@@ -2,6 +2,24 @@ package com.cwdarmm.repository;
 
 import com.cwdarmm.model.domain.BdMarket;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface BdMarketRepository extends JpaRepository<BdMarket, Long> {
+
+    /**
+     * Obtiene todas las filas de BD_MARKETS con sus relaciones cargadas.
+     */
+    @Query("""
+            select b from BdMarket b
+             join fetch b.account
+             join fetch b.market
+             join fetch b.marketData
+             join fetch b.contract
+             join fetch b.symbol
+            """)
+    List<BdMarket> findAllWithFetch();
 }

--- a/src/main/java/com/cwdarmm/service/MarketDbService.java
+++ b/src/main/java/com/cwdarmm/service/MarketDbService.java
@@ -1,48 +1,47 @@
 package com.cwdarmm.service;
 
+import com.cwdarmm.model.domain.BdMarket;
 import com.cwdarmm.model.dto.MarketDbRowDTO;
+import com.cwdarmm.repository.BdMarketRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Servicio que simula la carga de la hoja BD_MARKET.
  * Más adelante conectará a tu repositorio o parseará el XLSM.
  */
 @Service
+@RequiredArgsConstructor
 public class MarketDbService {
 
+    private final BdMarketRepository repository;
+
+    /**
+     * Devuelve todas las filas de la tabla BD_MARKETS mapeadas a DTO para la UI.
+     */
+    @Transactional(readOnly = true)
     public List<MarketDbRowDTO> listAll() {
-        // dummy: reproducimos exactamente los dos rows de tu captura
-        List<MarketDbRowDTO> list = new ArrayList<>();
+        return repository.findAllWithFetch().stream()
+                .map(this::toDTO)
+                .collect(Collectors.toList());
+    }
 
-        MarketDbRowDTO r1 = new MarketDbRowDTO();
-        r1.setFuture("S&P 500");
-        r1.setAccount("TRADEIFY");
-        r1.setMarketData("TRADOVATE");
-        r1.setName("E-mini S&P 500");
-        r1.setSymbol("ES");
-        r1.setMultiplier(50);
-        r1.setTickSize(0.25);
-        r1.setTickValue(12.5);
-        r1.setMargin(15400);
-        r1.setCommission(5.68);
-        list.add(r1);
-
-        MarketDbRowDTO r2 = new MarketDbRowDTO();
-        r2.setFuture("S&P 500");
-        r2.setAccount("TRADEIFY");
-        r2.setMarketData("TRADOVATE");
-        r2.setName("Micro E-mini S&P");
-        r2.setSymbol("MES");
-        r2.setMultiplier(5);
-        r2.setTickSize(0.25);
-        r2.setTickValue(1.25);
-        r2.setMargin(1540);
-        r2.setCommission(1.74);
-        list.add(r2);
-
-        return list;
+    private MarketDbRowDTO toDTO(BdMarket e) {
+        MarketDbRowDTO dto = new MarketDbRowDTO();
+        dto.setFuture(e.getMarket().getDescription());
+        dto.setAccount(e.getAccount().getDescription());
+        dto.setMarketData(e.getMarketData().getDescription());
+        dto.setName(e.getContract().getDescription());
+        dto.setSymbol(e.getSymbol().getSymbol());
+        dto.setMultiplier(e.getMultiplier());
+        dto.setTickSize(e.getTickSize());
+        dto.setTickValue(e.getTickValue());
+        dto.setMargin(e.getMargin());
+        dto.setCommission(e.getCommission());
+        return dto;
     }
 }

--- a/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
+++ b/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
@@ -102,8 +102,9 @@ public class RiskAnalysisService {
                                        int slTicks,
                                        BigDecimal riskPct) {
         // 1) currentRisk = accountSize * riskPct / 100
+        BigDecimal pct = riskPct == null ? BigDecimal.ONE : riskPct;
         BigDecimal currentRisk = in.getAccountSize()
-                .multiply(riskPct)
+                .multiply(pct)
                 .divide(BigDecimal.valueOf(100),
                         8,
                         BigDecimal.ROUND_HALF_UP);
@@ -130,8 +131,8 @@ public class RiskAnalysisService {
                 in.getRiskReward() * slTicks + offset
         );
 
-        // 5) LEEMOS EL SÍMBOLO directo del DTO: ES o MES
-        String futuresTicker = "MES";
+        // 5) Ticker del contrato desde BD_MARKET
+        String futuresTicker = db.getSymbol().get();
 
         // 6) Devolvemos la fila final
         if (optimalContracts.compareTo(BigDecimal.ONE) < 0) {


### PR DESCRIPTION
## Summary
- fetch BD market rows from the database using `findAllWithFetch`
- map BD markets to `MarketDbRowDTO`
- use the loaded risk percentages when building `RiskInputDTO`
- read the correct ticker and avoid null risk in optimal contract calculations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6885a6766898832d94a23a5592518055