### PR TITLE
Adjust cell coloring logic

### DIFF
--- a/src/main/java/com/cwdarmm/controller/OptimalContractsController.java
+++ b/src/main/java/com/cwdarmm/controller/OptimalContractsController.java
@@ -5,6 +5,7 @@ package com.cwdarmm.controller;
  * calculados para un trade.
  */
 
+import com.cwdarmm.model.domain.CatMarket;
 import com.cwdarmm.model.dto.OptimalContractRow;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.ReadOnlyStringWrapper;
@@ -13,6 +14,8 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
+import javafx.scene.control.TableCell;
+import javafx.util.Callback;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
@@ -28,12 +31,64 @@ public class OptimalContractsController {
     @FXML private TableColumn<OptimalContractRow, BigDecimal> colOptimal;
     @FXML private TableColumn<OptimalContractRow,Integer> colTarget;
 
+    private CatMarket market;
+
     @FXML
     public void initialize() {
         colSlSize .setCellValueFactory(c -> new ReadOnlyObjectWrapper<>(c.getValue().getSlSize()));
         colTicker .setCellValueFactory(c -> new ReadOnlyStringWrapper(c.getValue().getFuturesTicker()));
         colOptimal.setCellValueFactory(c -> new ReadOnlyObjectWrapper<>(c.getValue().getOptimalContract()));
         colTarget .setCellValueFactory(c -> new ReadOnlyObjectWrapper<>(c.getValue().getTargetTicks()));
+
+        // --- Cell styling to mimic the XLSM colors ---
+        colSlSize.setCellFactory(col -> new TableCell<>() {
+            @Override protected void updateItem(Integer item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || item==null) { setText(null); setStyle(""); }
+                else {
+                    setText(item.toString());
+                    setStyle("-fx-background-color:#FF0000; -fx-text-fill:white;");
+                }
+            }
+        });
+
+        colTarget.setCellFactory(col -> new TableCell<>() {
+            @Override protected void updateItem(Integer item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || item==null) { setText(null); setStyle(""); }
+                else {
+                    setText(item.toString());
+                    setStyle("-fx-background-color:#D3D3D3;");
+                }
+            }
+        });
+
+        Callback<TableColumn<OptimalContractRow, ?>, TableCell<OptimalContractRow, ?>> colorFactory = col -> new TableCell<>() {
+            @Override protected void updateItem(Object item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || item==null) { setText(null); setStyle(""); }
+                else {
+                    setText(item.toString());
+                    String c = colorForTicker(getTableView().getItems().get(getIndex()).getFuturesTicker());
+                    if (c != null && !c.isBlank()) setStyle("-fx-background-color:"+c+";");
+                    else setStyle("");
+                }
+            }
+        };
+
+        colTicker.setCellFactory(colorFactory);
+        colOptimal.setCellFactory(colorFactory);
+    }
+
+    private String colorForTicker(String ticker) {
+        if (market == null || ticker == null) return null;
+        boolean isMicro = ticker.startsWith("M");
+        String color = isMicro ? market.getColor1() : market.getColor2();
+        return color;
+    }
+
+    public void setMarket(CatMarket market) {
+        this.market = market;
     }
 
     public void setCriteriaAccount(String acc) {

--- a/src/main/java/com/cwdarmm/controller/ResultViewController.java
+++ b/src/main/java/com/cwdarmm/controller/ResultViewController.java
@@ -13,7 +13,6 @@ import com.cwdarmm.model.dto.MarketDTO;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
-import javafx.util.Callback;
 import javafx.stage.Stage;
 import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
@@ -60,36 +59,7 @@ public class ResultViewController {
         colLoss               .setCellValueFactory(cd -> cd.getValue().getPotentialLoss().asObject());
         colRiskPct            .setCellValueFactory(cd -> cd.getValue().getRiskPercentage().asObject());
 
-        // Estilos de columnas según colores del XLSM
-        colSlSize.setCellFactory(col -> new TableCell<>() {
-            @Override protected void updateItem(Integer item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item==null) { setText(null); setStyle(""); }
-                else {
-                    setText(item.toString());
-                    setStyle("-fx-background-color:#FF0000; -fx-text-fill:white;");
-                }
-            }
-        });
-
-        colTarget.setCellFactory(col -> new TableCell<ResultRowDTO, Integer>() {
-            @Override
-            protected void updateItem(Integer item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
-                    setStyle("");
-                } else {
-                    setText(item.toString());
-                    setStyle("-fx-background-color:#D3D3D3;");
-                }
-            }
-        });
-
-
-        // 3) Usamos el factory genérico para Symbol y OptimalContract
-        colSymbol          .setCellFactory(coloredFactory());
-        colOptimalContract .setCellFactory(coloredFactory());
+        // Estilos de filas resaltadas
 
         // 4) RowFactory para filas óptimas
         tblResults.setRowFactory(tv -> new TableRow<ResultRowDTO>() {
@@ -109,32 +79,6 @@ public class ResultViewController {
         // 5) Inicialmente vacío
         tblResults.setItems(FXCollections.observableArrayList());
     }
-    /**
-     * Método genérico para crear un cellFactory que colorea según row.getRowColor()
-     */
-    @SuppressWarnings("unchecked")
-    private <T> Callback<TableColumn<ResultRowDTO, T>, TableCell<ResultRowDTO, T>> coloredFactory() {
-        return column -> new TableCell<ResultRowDTO, T>() {
-            @Override
-            protected void updateItem(T item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
-                    setStyle("");
-                } else {
-                    setText(item.toString());
-                    ResultRowDTO row = getTableView().getItems().get(getIndex());
-                    String color = row.getRowColor().get();
-                    if (color != null && !color.isBlank()) {
-                        setStyle("-fx-background-color:" + color + ";");
-                    } else {
-                        setStyle("");
-                    }
-                }
-            }
-        };
-    }
-
     /**
      * Ejecuta el cálculo real de la pestaña Results utilizando la primera
      * configuración guardada en la tabla OpenMarket como ejemplo.

--- a/src/main/java/com/cwdarmm/controller/RiskConfigController.java
+++ b/src/main/java/com/cwdarmm/controller/RiskConfigController.java
@@ -172,14 +172,15 @@ public class RiskConfigController {
 
         // 8) Mostrar ventana de Optimal Contracts
         List<OptimalContractRow> optimalRows = riskAnalysisService.generateOptimalContracts(req);
-        showOptimalContracts(optimalRows, req.getAccount().getDescription());
+        showOptimalContracts(optimalRows, req.getAccount().getDescription(), req.getMarket());
         dialogStage.close();
     }
 
-    private void showOptimalContracts(List<OptimalContractRow> rows, String criteriaAccount) throws IOException {
+    private void showOptimalContracts(List<OptimalContractRow> rows, String criteriaAccount, CatMarket market) throws IOException {
         FXMLLoader loader = springFXMLLoader.load("/fxml/OptimalContractsView.fxml");
         OptimalContractsController ctrl = loader.getController();
         ctrl.setCriteriaAccount(criteriaAccount);
+        ctrl.setMarket(market);
         ctrl.setItems(rows);
 
         Stage popup = new Stage();


### PR DESCRIPTION
## Summary
- remove cell highlighting from Optimization Results table
- apply coloring when showing Optimal Contracts instead
- pass `CatMarket` to `OptimalContractsController` for color lookups

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68869ac7a388832db742931b1d47c303