### PR TITLE
Fix primer trade risk logic

### DIFF
--- a/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
+++ b/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
@@ -138,19 +138,24 @@ public class RiskAnalysisService {
         CatContract contract = chosen.getContract();
         CatSymbol symbol = chosen.getSymbol();
 
-        // 3) Ajustamos el riesgo con un multiplicador, ver fórmula de
-        //    "risk adjustment" en docs/GOOD ARTICLE.pdf
-        BigDecimal multiplier = in.isWin() ? new BigDecimal("1.05") : new BigDecimal("0.98");
-        BigDecimal riskA = in.getRiskPctA() == null ? null : in.getRiskPctA().multiply(multiplier);
-        BigDecimal riskB = in.getRiskPctB() == null ? null : in.getRiskPctB().multiply(multiplier);
+        // 3) Ajustamos el riesgo con un multiplicador (compounding/drawdown)
+        //    salvo en el primer trade, donde se usa el valor "en crudo" tal
+        //    como se indicó en el formulario.
+        BigDecimal riskA = in.getRiskPctA();
+        BigDecimal riskB = in.getRiskPctB();
+        if (!in.isFirstTrade()) {
+            BigDecimal multiplier = in.isWin() ? new BigDecimal("1.05") : new BigDecimal("0.98");
+            riskA = riskA == null ? null : riskA.multiply(multiplier);
+            riskB = riskB == null ? null : riskB.multiply(multiplier);
+        }
 
         // 4) Determinamos el offset para el cálculo de targets según el mercado
         int offset = offsetForMarket(in.getMarket());
 
         // 5) Generamos una fila para cada "bote" (House/Lunch)
         return Stream.of(
-                        in.isHouse() ? makeRowRange(in, chosen, riskA, contract, symbol, offset) : null,
-                        in.isLunch() ? makeRowRange(in, chosen, riskB, contract, symbol, offset) : null
+                        in.isHouse() ? makeRowRange(in, chosen, riskA, contract, symbol, offset, in.isFirstTrade()) : null,
+                        in.isLunch() ? makeRowRange(in, chosen, riskB, contract, symbol, offset, in.isFirstTrade()) : null
                 )
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
@@ -166,7 +171,8 @@ public class RiskAnalysisService {
                                             BigDecimal riskPct,
                                             CatContract contract,
                                             CatSymbol symbol,
-                                            int offset) {
+                                            int offset,
+                                            boolean firstTrade) {
         // --- Mapeo directo de las celdas de Excel al código Java ---
         // 1) Calcular el riesgo disponible para este trade
         //    (sección "Risk per trade" en docs/GOOD ARTICLE.pdf)
@@ -189,10 +195,14 @@ public class RiskAnalysisService {
 
         // 3) Recorremos cada posible SL buscando la mejor relación
         for (int sl = start; sl <= end; sl++) {
-            // 3.a) Riesgo por contrato = ticks SL * tickValue + comisión
+            // 3.a) Riesgo por contrato = ticks SL * tickValue.
+            //     En trades posteriores sumamos la comisión, pero para el
+            //     primer trade se utiliza la fórmula "pura" del artículo.
             BigDecimal riskPerContract = tickValue
-                    .multiply(BigDecimal.valueOf(sl))
-                    .add(commission);
+                    .multiply(BigDecimal.valueOf(sl));
+            if (!firstTrade) {
+                riskPerContract = riskPerContract.add(commission);
+            }
 
             if (riskPerContract.compareTo(BigDecimal.ZERO) <= 0) continue;
 

--- a/src/test/java/com/cwdarmm/service/RiskAnalysisServiceOptimalTest.java
+++ b/src/test/java/com/cwdarmm/service/RiskAnalysisServiceOptimalTest.java
@@ -81,4 +81,54 @@ public class RiskAnalysisServiceOptimalTest {
         assertEquals(new BigDecimal("1"), row.getOptimalContract()); // Con $200 y stop pequeño, puedes meter 1 contrato
         assertEquals(3, row.getTargetTicks()); // Si riesgo=1 tick y reward=2, objetivo = 1 + 2 = 3 ticks
     }
+
+    /**
+     * 🔹 Escenario: cálculo en el primer trade.
+     *  Con las mismas condiciones que en el Excel, debe devolver
+     *  el ticker "ES" y 5 contratos óptimos.
+     */
+    @Test
+    void optimalContractsFirstTrade() {
+        BdMarket es = BdMarket.builder()
+                .id(2L)
+                .account(CatAccount.builder().id(1L).description("NEXGEN").build())
+                .market(CatMarket.builder().id(2L).description("S&P 500").build())
+                .marketData(CatMarketData.builder().id(3L).description("PROJECTX").build())
+                .contract(CatContract.builder().id(3L).description("E-mini S&P 500").build())
+                .symbol(CatSymbol.builder().id(3L).symbol("ES").build())
+                .multiplier(50.0)
+                .tickSize(0.25)
+                .tickValue(12.5)
+                .margin(15400.0)
+                .commission(2.08)
+                .build();
+
+        BdMarketRepository repo = Mockito.mock(BdMarketRepository.class);
+        Mockito.when(repo.findOneByMktAccMdata(2L,1L,3L))
+                .thenReturn(List.of(es));
+
+        RiskAnalysisService service = new RiskAnalysisService(repo);
+
+        RiskInputDTO req = RiskInputDTO.builder()
+                .account(es.getAccount())
+                .market(es.getMarket())
+                .marketData(es.getMarketData())
+                .accountSize(new BigDecimal("200"))
+                .riskReward(3)
+                .ticksSl1(1)
+                .ticksSl2(1)
+                .house(true)
+                .lunch(false)
+                .win(true)
+                .firstTrade(true)
+                .riskPctA(new BigDecimal("2.5"))
+                .build();
+
+        List<OptimalContractRow> rows = service.generateOptimalContracts(req);
+        assertEquals(1, rows.size());
+
+        OptimalContractRow row = rows.get(0);
+        assertEquals("ES", row.getFuturesTicker());
+        assertEquals(new BigDecimal("5"), row.getOptimalContract());
+    }
 }


### PR DESCRIPTION
## Summary
- avoid risk adjustment on first trade
- compute risk per contract without commissions in first trade
- add unit test for first trade scenario

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6889a2114374832da6fe49a62ce922e2