### PR TITLE
Add BD_MARKET filtering

### DIFF
--- a/src/main/java/com/cwdarmm/controller/BdMarketController.java
+++ b/src/main/java/com/cwdarmm/controller/BdMarketController.java
@@ -82,7 +82,7 @@ public class BdMarketController {
     }
 
     private void refreshTable() {
-        List<MarketDbRowDTO> rows = marketDbService.listAll();
+        List<MarketDbRowDTO> rows = marketDbService.listByCriteria();
         tblMarketDb.setItems(FXCollections.observableArrayList(rows));
     }
 

--- a/src/main/java/com/cwdarmm/controller/RiskConfigController.java
+++ b/src/main/java/com/cwdarmm/controller/RiskConfigController.java
@@ -15,6 +15,7 @@ import com.cwdarmm.model.dto.RiskResultDTO;
 import com.cwdarmm.service.ReferenceDataService;
 import com.cwdarmm.service.ExportService;
 import com.cwdarmm.service.RiskAnalysisService;
+import com.cwdarmm.service.MarketDbService;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
@@ -41,6 +42,7 @@ public class RiskConfigController {
     private final RiskAnalysisService riskAnalysisService;
     private final ReferenceDataService referenceDataService;
     private final ExportService exportService;
+    private final MarketDbService marketDbService;
     private final SpringFXMLLoader springFXMLLoader;
     private Stage dialogStage;
     private Consumer<RiskInputDTO> onCalculated;
@@ -169,6 +171,8 @@ public class RiskConfigController {
                              .toBuilder()
                              .firstTrade(first)
                             .build();
+        // Guardamos este criterio para filtrar BD_MARKET
+        marketDbService.setCurrentCriteria(req);
 
         // 5) Llamamos al servicio que **YA NO** simula nada, solo construye INITIAL + OPTIMAL
         List<RiskResultDTO> rows = riskAnalysisService.calculate(req);

--- a/src/main/java/com/cwdarmm/service/MarketDbService.java
+++ b/src/main/java/com/cwdarmm/service/MarketDbService.java
@@ -11,6 +11,7 @@ import com.cwdarmm.repository.BdMarketRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.cwdarmm.model.dto.RiskInputDTO;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,9 +22,27 @@ import java.util.stream.Collectors;
 public class MarketDbService {
 
     private final BdMarketRepository bdMarketRepo;
+    private RiskInputDTO currentCriteria;
 
     public List<MarketDbRowDTO> listAll() {
         return bdMarketRepo.findAll().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    public void setCurrentCriteria(RiskInputDTO req) {
+        this.currentCriteria = req;
+    }
+
+    public List<MarketDbRowDTO> listByCriteria() {
+        if (currentCriteria == null) {
+            return listAll();
+        }
+        return bdMarketRepo.findOneByMktAccMdata(
+                currentCriteria.getMarket().getId(),
+                currentCriteria.getAccount().getId(),
+                currentCriteria.getMarketData().getId()
+        ).stream()
                 .map(this::toDto)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## Summary
- track last risk criteria in `MarketDbService`
- store request from `RiskConfigController` for later queries
- filter Market DB table based on last criteria

## Testing
- `mvn -q -o test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688a3dd7b79c832d977eb22f612e7779