### PR TITLE
Improve BD market filtering

### DIFF
--- a/src/main/java/com/cwdarmm/controller/BdMarketController.java
+++ b/src/main/java/com/cwdarmm/controller/BdMarketController.java
@@ -7,7 +7,9 @@ package com.cwdarmm.controller;
 
 import com.cwdarmm.model.domain.*;
 import com.cwdarmm.model.dto.MarketDbRowDTO;
+import com.cwdarmm.model.dto.MarketDTO;
 import com.cwdarmm.service.MarketDbService;
+import com.cwdarmm.service.MarketDataService;
 import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
@@ -35,6 +37,7 @@ public class BdMarketController {
     @FXML private TableColumn<MarketDbRowDTO, Double>  colCommission;
 
     private final MarketDbService marketDbService;
+    private final MarketDataService marketDataService;
     private Stage dialogStage;
 
     @FXML
@@ -82,7 +85,24 @@ public class BdMarketController {
     }
 
     private void refreshTable() {
-        List<MarketDbRowDTO> rows = marketDbService.listAll();
+        List<MarketDTO> sessions = marketDataService.findAll();
+        List<MarketDbRowDTO> rows;
+
+        if (sessions.isEmpty()) {
+            rows = marketDbService.listAll();
+        } else {
+            rows = new java.util.ArrayList<>();
+            for (MarketDTO s : sessions) {
+                rows.addAll(
+                        marketDbService.listBy(
+                                s.getMarket().getId(),
+                                s.getAccount().getId(),
+                                s.getMarketData().getId()
+                        )
+                );
+            }
+        }
+
         tblMarketDb.setItems(FXCollections.observableArrayList(rows));
     }
 

--- a/src/main/java/com/cwdarmm/service/MarketDbService.java
+++ b/src/main/java/com/cwdarmm/service/MarketDbService.java
@@ -28,6 +28,17 @@ public class MarketDbService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Lista las configuraciones de {@code bd_markets} filtrando por
+     * mercado, cuenta y feed de datos.
+     */
+    public List<MarketDbRowDTO> listBy(Long marketId, Long accountId, Long marketDataId) {
+        return bdMarketRepo.findOneByMktAccMdata(marketId, accountId, marketDataId)
+                .stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
     private MarketDbRowDTO toDto(BdMarket bd) {
         // ——————————————————————————————————————————————————
         // F O R Z A M O S   L A   C A R G A   D E   L O S   A S O C I A D O S


### PR DESCRIPTION
## Summary
- filter BD market table using the active open market sessions
- provide method to query bd_markets by market/account/feed

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688a3dd7b79c832d977eb22f612e7779