### PR TITLE
Auto refresh BD market table on tab switch

### DIFF
--- a/src/main/java/com/cwdarmm/controller/BdMarketController.java
+++ b/src/main/java/com/cwdarmm/controller/BdMarketController.java
@@ -84,7 +84,7 @@ public class BdMarketController {
         refreshTable();
     }
 
-    private void refreshTable() {
+    public void refreshTable() {
         List<MarketDTO> sessions = marketDataService.findAll();
         List<MarketDbRowDTO> rows;
 

--- a/src/main/java/com/cwdarmm/controller/MainWindowController.java
+++ b/src/main/java/com/cwdarmm/controller/MainWindowController.java
@@ -7,8 +7,9 @@ package com.cwdarmm.controller;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.TabPane;
-import org.springframework.stereotype.Component;
+import javafx.scene.control.Tab;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -18,11 +19,21 @@ public class MainWindowController {
     @FXML private javafx.scene.control.Tab tabMarkets;
 
     @FXML private javafx.scene.control.Tab tabResults;
+    @FXML private javafx.scene.control.Tab tabMarketDb;
+
+    private final BdMarketController bdMarketController;
 
     @FXML
     public void initialize() {
         // Seleccionamos la pestaña Markets por defecto al arrancar
         tabPane.getSelectionModel().select(tabMarkets);
+
+        // Al cambiar a la pestaña BD Market recargamos su tabla
+        tabMarketDb.setOnSelectionChanged(ev -> {
+            if (tabMarketDb.isSelected()) {
+                bdMarketController.refreshTable();
+            }
+        });
     }
 
     // Métodos para cambiar de pestaña desde código si los necesitas:

--- a/src/main/java/com/cwdarmm/controller/RiskConfigController.java
+++ b/src/main/java/com/cwdarmm/controller/RiskConfigController.java
@@ -15,6 +15,7 @@ import com.cwdarmm.model.dto.RiskResultDTO;
 import com.cwdarmm.service.ReferenceDataService;
 import com.cwdarmm.service.ExportService;
 import com.cwdarmm.service.RiskAnalysisService;
+import com.cwdarmm.controller.BdMarketController;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
@@ -42,6 +43,7 @@ public class RiskConfigController {
     private final ReferenceDataService referenceDataService;
     private final ExportService exportService;
     private final SpringFXMLLoader springFXMLLoader;
+    private final BdMarketController bdMarketController;
     private Stage dialogStage;
     private Consumer<RiskInputDTO> onCalculated;
     private MarketDTO marketContext;
@@ -197,6 +199,7 @@ public class RiskConfigController {
         // 8) Mostrar ventana de Optimal Contracts
         List<OptimalContractRow> optimalRows = riskAnalysisService.generateOptimalContracts(req);
         showOptimalContracts(optimalRows, req.getAccount().getDescription(), req.getMarket());
+        bdMarketController.refreshTable();
         dialogStage.close();
     }
 


### PR DESCRIPTION
## Summary
- expose `refreshTable` so other controllers can call it
- auto-refresh BD market view when switching tabs
- update risk config flow to refresh BD market after running optimal contracts

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688c444907fc832da24f2884af392f67