### PR TITLE
fix: include commission in first trade risk calculation

### DIFF
--- a/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
+++ b/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
@@ -205,14 +205,12 @@ public class RiskAnalysisService {
 
         // 3) Recorremos cada posible SL buscando la mejor relación
         for (int sl = start; sl <= end; sl++) {
-            // 3.a) Riesgo por contrato = ticks SL * tickValue.
-            //     En trades posteriores sumamos la comisión, pero para el
-            //     primer trade se utiliza la fórmula "pura" del artículo.
+            // 3.a) Riesgo por contrato = ticks SL * tickValue + comisión.
+            //     La versión VBA siempre suma la comisión al riesgo por
+            //     contrato, incluso en el primer trade.
             BigDecimal riskPerContract = tickValue
-                    .multiply(BigDecimal.valueOf(sl));
-            if (!firstTrade) {
-                riskPerContract = riskPerContract.add(commission);
-            }
+                    .multiply(BigDecimal.valueOf(sl))
+                    .add(commission);
             log.debug("sl={}, riskPerContract={}", sl, riskPerContract);
 
             if (riskPerContract.compareTo(BigDecimal.ZERO) <= 0) continue;

--- a/src/test/java/com/cwdarmm/service/RiskAnalysisServiceOptimalTest.java
+++ b/src/test/java/com/cwdarmm/service/RiskAnalysisServiceOptimalTest.java
@@ -131,4 +131,51 @@ public class RiskAnalysisServiceOptimalTest {
         assertEquals("ES", row.getFuturesTicker());
         assertEquals(new BigDecimal("5"), row.getOptimalContract());
     }
+
+    /**
+     * 🔹 Escenario: en el primer trade sí se suma la comisión al riesgo por contrato.
+     *  Con una cuenta más grande, el cálculo debe devolver 3 contratos óptimos
+     *  cuando el riesgo disponible es $50 y cada contrato arriesga 14.58.
+     */
+    @Test
+    void commissionIncludedOnFirstTrade() {
+        BdMarket es = BdMarket.builder()
+                .id(2L)
+                .account(CatAccount.builder().id(1L).description("NEXGEN").build())
+                .market(CatMarket.builder().id(2L).description("S&P 500").build())
+                .marketData(CatMarketData.builder().id(3L).description("PROJECTX").build())
+                .contract(CatContract.builder().id(3L).description("E-mini S&P 500").build())
+                .symbol(CatSymbol.builder().id(3L).symbol("ES").build())
+                .multiplier(50.0)
+                .tickSize(0.25)
+                .tickValue(12.5)
+                .margin(15400.0)
+                .commission(2.08)
+                .build();
+
+        BdMarketRepository repo = Mockito.mock(BdMarketRepository.class);
+        Mockito.when(repo.findOneByMktAccMdata(2L,1L,3L))
+                .thenReturn(List.of(es));
+
+        RiskAnalysisService service = new RiskAnalysisService(repo);
+
+        RiskInputDTO req = RiskInputDTO.builder()
+                .account(es.getAccount())
+                .market(es.getMarket())
+                .marketData(es.getMarketData())
+                .accountSize(new BigDecimal("2000"))
+                .riskReward(3)
+                .ticksSl1(1)
+                .ticksSl2(1)
+                .house(true)
+                .firstTrade(true)
+                .riskPctA(new BigDecimal("2.5"))
+                .build();
+
+        List<OptimalContractRow> rows = service.generateOptimalContracts(req);
+        assertEquals(1, rows.size());
+
+        OptimalContractRow row = rows.get(0);
+        assertEquals(new BigDecimal("3"), row.getOptimalContract());
+    }
 }


### PR DESCRIPTION
## Summary
- ensure risk per contract always adds commission so Java matches Excel macros
- add unit test proving commission is applied on first trade

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.cwdarmm:cw-darmm:1.0.0: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.3.0 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_689116b073a4832d9da0b9ac3e01f3b0