### PR TITLE
Use risk config in results and fix first-trade contracts

### DIFF
--- a/src/main/java/com/cwdarmm/controller/ResultViewController.java
+++ b/src/main/java/com/cwdarmm/controller/ResultViewController.java
@@ -43,6 +43,14 @@ public class ResultViewController {
 
     private Stage dialogStage;
 
+    /**
+     * Request de entrada con los parámetros que el usuario capturó
+     * en la ventana de configuración de riesgo. Si se establece desde
+     * otro controlador, la pestaña Results utilizará exactamente esos
+     * valores en lugar de los ejemplos fijos que se usaban antes.
+     */
+    private RiskInputDTO request;
+
     @FXML
     public void initialize() {
         // Configuramos cada columna para que lea la propiedad correspondiente de ResultRowDTO
@@ -79,31 +87,45 @@ public class ResultViewController {
         // 5) Inicialmente vacío
         tblResults.setItems(FXCollections.observableArrayList());
     }
+
     /**
-     * Ejecuta el cálculo real de la pestaña Results utilizando la primera
-     * configuración guardada en la tabla OpenMarket como ejemplo.
+     * Permite inyectar desde fuera la configuración con la que
+     * se desea ejecutar la optimización.
+     */
+    public void setRequest(RiskInputDTO request) {
+        this.request = request;
+    }
+    /**
+     * Ejecuta el cálculo real de la pestaña Results.
+     *
+     * <p>Si otro controlador proporcionó un {@link RiskInputDTO} mediante
+     * {@link #setRequest(RiskInputDTO)}, se utilizará esa configuración
+     * exactamente. En caso contrario se intentará usar la primera sesión
+     * almacenada en la base de datos como ejemplo sencillo.</p>
      */
     @FXML
     private void onClick() {
-        List<MarketDTO> markets = marketDataService.findAll();
-        if (markets.isEmpty()) {
-            new Alert(Alert.AlertType.INFORMATION, "No market sessions configured").showAndWait();
-            return;
+        RiskInputDTO req = this.request;
+        if (req == null) {
+            List<MarketDTO> markets = marketDataService.findAll();
+            if (markets.isEmpty()) {
+                new Alert(Alert.AlertType.INFORMATION, "No market sessions configured").showAndWait();
+                return;
+            }
+            MarketDTO m = markets.get(0);
+            req = RiskInputDTO.builder()
+                    .account(m.getAccount())
+                    .market(m.getMarket())
+                    .marketData(m.getMarketData())
+                    .accountSize(m.getAccountSize())
+                    .riskReward(1.0)
+                    .ticksSl1(1)
+                    .ticksSl2(1)
+                    .house(true)
+                    .firstTrade(true)
+                    .riskPctA(java.math.BigDecimal.valueOf(m.getRiskA()))
+                    .build();
         }
-
-        MarketDTO m = markets.get(0);
-        RiskInputDTO req = RiskInputDTO.builder()
-                .account(m.getAccount())
-                .market(m.getMarket())
-                .marketData(m.getMarketData())
-                .accountSize(m.getAccountSize())
-                .riskReward(2.0)
-                .ticksSl1(10)
-                .ticksSl2(15)
-                .house(true)
-                .firstTrade(true)
-                .riskPctA(java.math.BigDecimal.valueOf(m.getRiskA()))
-                .build();
 
         List<ResultRowDTO> rows = optimizationService.calculate(req);
         tblResults.setItems(FXCollections.observableArrayList(rows));

--- a/src/main/java/com/cwdarmm/service/OptimizationService.java
+++ b/src/main/java/com/cwdarmm/service/OptimizationService.java
@@ -137,6 +137,13 @@ public class OptimizationService {
                     if (riskPerContract <= 0) continue;
 
                     int optimal = (int) Math.floor(currentRisk / riskPerContract);
+                    if (optimal < 1 && in.isFirstTrade()) {
+                        // En el primer trade el Excel permite operar 5 contratos
+                        // a modo de "bote" inicial aunque el riesgo disponible
+                        // no alcance.
+                        optimal = 5;
+                    }
+
                     double capitalUsed = optimal * riskPerContract;
                     double realRisk = capitalUsed * 100.0 / in.getAccountSize().doubleValue();
                     int target = (int) Math.round(in.getRiskReward() * sl + offset);

--- a/src/test/java/com/cwdarmm/service/OptimizationServiceCalculateTest.java
+++ b/src/test/java/com/cwdarmm/service/OptimizationServiceCalculateTest.java
@@ -1,0 +1,67 @@
+package com.cwdarmm.service;
+
+import com.cwdarmm.model.domain.*;
+import com.cwdarmm.model.dto.ResultRowDTO;
+import com.cwdarmm.model.dto.RiskInputDTO;
+import com.cwdarmm.repository.BdMarketRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link OptimizationService#calculate(RiskInputDTO)} ensuring
+ * the Java implementation mirrors the formulas from risk_market.frm.
+ */
+public class OptimizationServiceCalculateTest {
+
+    /**
+     * When the available risk is insufficient in the first trade, the
+     * Excel macro allows trading 5 contracts. The target ticks must
+     * respect the configured risk-reward ratio.
+     */
+    @Test
+    void firstTradeUsesFiveContractsAndRespectsTarget() {
+        BdMarket bd = BdMarket.builder()
+                .id(1L)
+                .account(CatAccount.builder().id(1L).description("NEXGEN").build())
+                .market(CatMarket.builder().id(1L).description("NASDAQ").build())
+                .marketData(CatMarketData.builder().id(1L).description("PROJECTX").build())
+                .contract(CatContract.builder().id(1L).description("E-mini NASDAQ").build())
+                .symbol(CatSymbol.builder().id(1L).symbol("NQ").build())
+                .tickValue(12.5)
+                .commission(2.0)
+                .build();
+
+        BdMarketRepository repo = Mockito.mock(BdMarketRepository.class);
+        Mockito.when(repo.findOneByMktAccMdata(1L,1L,1L))
+                .thenReturn(List.of(bd));
+
+        OptimizationService svc = new OptimizationService(repo);
+
+        RiskInputDTO req = RiskInputDTO.builder()
+                .account(bd.getAccount())
+                .market(bd.getMarket())
+                .marketData(bd.getMarketData())
+                .accountSize(new BigDecimal("200"))
+                .riskReward(1.0)
+                .ticksSl1(1)
+                .ticksSl2(1)
+                .house(true)
+                .firstTrade(true)
+                .riskPctA(new BigDecimal("2.5"))
+                .build();
+
+        List<ResultRowDTO> rows = svc.calculate(req);
+        assertEquals(2, rows.size()); // two rows: for k=0 and k=1
+
+        ResultRowDTO row = rows.get(0);
+        assertEquals(1, row.getSlSize().get());
+        assertEquals(3, row.getTarget().get()); // 1*1 + offset(2)
+        assertEquals(5, row.getOptimalContract().get());
+    }
+}
+


### PR DESCRIPTION
## Summary
- Allow ResultViewController to receive external RiskInputDTO and use it instead of hard-coded demo values, ensuring the Results tab reflects the configuration captured by the user.
- Mirror VBA behavior in OptimizationService by allocating five contracts when the first trade lacks sufficient risk and compute capital/profit with this fallback.
- Add regression test confirming that initial trades with insufficient risk still trade five contracts and honor the risk-reward target.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.cwdarmm:cw-darmm:1.0.0 … Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68919516b990832dad0ea88277fd48fa