### PR TITLE
Add test for S&P optimal contract scenario

### DIFF
--- a/src/test/java/com/cwdarmm/service/OptimizationServiceCalculateTest.java
+++ b/src/test/java/com/cwdarmm/service/OptimizationServiceCalculateTest.java
@@ -63,5 +63,79 @@ public class OptimizationServiceCalculateTest {
         assertEquals(3, row.getTarget().get()); // 1*1 + offset(2)
         assertEquals(5, row.getOptimalContract().get());
     }
+
+    @Test
+    void reproducesExcelScenario() {
+        // Two contracts for the S&P 500: regular ES and micro MES
+        CatAccount account = CatAccount.builder().id(1L).description("NEXGEN").build();
+        CatMarket market = CatMarket.builder().id(1L).description("S&P 500").build();
+        CatMarketData md = CatMarketData.builder().id(1L).description("PROJECTX").build();
+
+        BdMarket es = BdMarket.builder()
+                .id(1L)
+                .account(account)
+                .market(market)
+                .marketData(md)
+                .contract(CatContract.builder().id(1L).description("E-mini S&P 500").build())
+                .symbol(CatSymbol.builder().id(1L).symbol("ES").build())
+                .tickValue(12.5)
+                .commission(2.08)
+                .build();
+
+        BdMarket mes = BdMarket.builder()
+                .id(2L)
+                .account(account)
+                .market(market)
+                .marketData(md)
+                .contract(CatContract.builder().id(2L).description("Micro E-mini S&P 500").build())
+                .symbol(CatSymbol.builder().id(2L).symbol("MES").build())
+                .tickValue(1.25)
+                .commission(0.74)
+                .build();
+
+        BdMarketRepository repo = Mockito.mock(BdMarketRepository.class);
+        Mockito.when(repo.findOneByMktAccMdata(1L,1L,1L))
+                .thenReturn(List.of(es, mes));
+
+        OptimizationService svc = new OptimizationService(repo);
+
+        RiskInputDTO req = RiskInputDTO.builder()
+                .account(account)
+                .market(market)
+                .marketData(md)
+                .accountSize(new BigDecimal("200"))
+                .riskReward(2.0)
+                .ticksSl1(1)
+                .ticksSl2(1)
+                .house(true)
+                .firstTrade(false)
+                .riskPctA(new BigDecimal("1.575"))
+                .build();
+
+        List<ResultRowDTO> rows = svc.calculate(req);
+        assertEquals(4, rows.size());
+
+        // ES with risk 1.575
+        ResultRowDTO esRow = rows.stream()
+                .filter(r -> r.getSymbol().get().equals("ES") && r.getRiskPercentage().get() == 1.575)
+                .findFirst().orElseThrow();
+        assertEquals(3, esRow.getTarget().get());
+        assertEquals(1, esRow.getSlSize().get());
+        assertEquals(14.58, esRow.getRiskPerContract().get(), 1e-2);
+        assertEquals(0, esRow.getOptimalContract().get());
+
+        // MES with risk 1.575
+        ResultRowDTO mesRow = rows.stream()
+                .filter(r -> r.getSymbol().get().equals("MES") && r.getRiskPercentage().get() == 1.575)
+                .findFirst().orElseThrow();
+        assertEquals(3, mesRow.getTarget().get());
+        assertEquals(1, mesRow.getSlSize().get());
+        assertEquals(1.99, mesRow.getRiskPerContract().get(), 1e-2);
+        assertEquals(1, mesRow.getOptimalContract().get());
+        assertEquals(1.99, mesRow.getCapitalUsed().get(), 1e-2);
+        assertEquals(0.995, mesRow.getRealRisk().get(), 1e-3);
+        assertEquals(3.01, mesRow.getPotentialProfit().get(), 1e-2);
+        assertEquals(1.99, mesRow.getPotentialLoss().get(), 1e-2);
+    }
 }
 


### PR DESCRIPTION
## Summary
- add regression test verifying ES/MES optimal contract calculations against Excel example

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.0: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894280466cc832d8006c8232225bbb2