### PR TITLE
Handle multiple risk percentages in optimization results

### DIFF
--- a/src/main/java/com/cwdarmm/service/OptimizationService.java
+++ b/src/main/java/com/cwdarmm/service/OptimizationService.java
@@ -109,68 +109,86 @@ public class OptimizationService {
 
         List<ResultRowDTO> results = new ArrayList<>();
 
-        // Riesgo inicial ajustado por resultado WIN/LOSS
-        java.math.BigDecimal riskPct = in.isHouse() ? in.getRiskPctA() : in.getRiskPctB();
-        if (riskPct == null) riskPct = java.math.BigDecimal.ZERO;
-        if (!in.isFirstTrade()) {
-            java.math.BigDecimal mult = in.isWin() ? new java.math.BigDecimal("1.05") : new java.math.BigDecimal("0.98");
-            riskPct = riskPct.multiply(mult);
-        }
-        double pctBase = riskPct.doubleValue();
-        double x = pctBase < 1.0 ? 0.03 : 0.1;
-
         int start = in.getTicksSl1();
         int end   = in.getTicksSl2() >= start ? in.getTicksSl2() : start;
 
         int offset = "NASDAQ".equalsIgnoreCase(in.getMarket().getDescription()) ? 2 : 1;
 
-        for (BdMarket bd : rows) {
-            double tickValue = bd.getTickValue();
-            double commission = bd.getCommission();
-            String symbol = bd.getSymbol().getSymbol();
+        // En el Excel original se calculan los escenarios para cada "bote"
+        // (House y Lunch). En la versión previa sólo se tomaba uno de los
+        // porcentajes de riesgo, lo que provocaba que los resultados
+        // correspondieran siempre a Kelly A. Aquí construimos una lista con
+        // los porcentajes base activos y calculamos para cada uno.
+        List<java.math.BigDecimal> baseRiskPcts = new ArrayList<>();
+        if (in.isHouse() && in.getRiskPctA() != null) {
+            baseRiskPcts.add(in.getRiskPctA());
+        }
+        if (in.isLunch() && in.getRiskPctB() != null) {
+            baseRiskPcts.add(in.getRiskPctB());
+        }
+        if (baseRiskPcts.isEmpty()) {
+            baseRiskPcts.add(java.math.BigDecimal.ZERO);
+        }
 
-            for (int sl = start; sl <= end; sl++) {
-                for (int k = 0; k < 2; k++) {
-                    double riskPctApplied = pctBase + (x * k);
-                    double currentRisk = in.getAccountSize().doubleValue() * riskPctApplied / 100.0;
-                    double riskPerContract = tickValue * sl + commission;
-                    if (riskPerContract <= 0) continue;
+        for (java.math.BigDecimal basePct : baseRiskPcts) {
+            // Ajuste por compounding según resultado del trade
+            if (!in.isFirstTrade()) {
+                java.math.BigDecimal mult = in.isWin()
+                        ? new java.math.BigDecimal("1.05")
+                        : new java.math.BigDecimal("0.98");
+                basePct = basePct.multiply(mult);
+            }
+            double pctBase = basePct.doubleValue();
+            double x = pctBase < 1.0 ? 0.03 : 0.1;
 
-                    int optimal = (int) Math.floor(currentRisk / riskPerContract);
-                    if (optimal < 1 && in.isFirstTrade()) {
-                        // En el primer trade el Excel permite operar 5 contratos
-                        // a modo de "bote" inicial aunque el riesgo disponible
-                        // no alcance.
-                        optimal = 5;
+            for (BdMarket bd : rows) {
+                double tickValue = bd.getTickValue();
+                double commission = bd.getCommission();
+                String symbol = bd.getSymbol().getSymbol();
+
+                for (int sl = start; sl <= end; sl++) {
+                    for (int k = 0; k < 2; k++) {
+                        double riskPctApplied = pctBase + (x * k);
+                        double currentRisk = in.getAccountSize().doubleValue() * riskPctApplied / 100.0;
+                        double riskPerContract = tickValue * sl + commission;
+                        if (riskPerContract <= 0) continue;
+
+                        int optimal = (int) Math.floor(currentRisk / riskPerContract);
+                        if (optimal < 1 && in.isFirstTrade()) {
+                            // En el primer trade el Excel permite operar 5 contratos
+                            // a modo de "bote" inicial aunque el riesgo disponible
+                            // no alcance.
+                            optimal = 5;
+                        }
+
+                        double capitalUsed = optimal * riskPerContract;
+                        double realRisk = capitalUsed * 100.0 / in.getAccountSize().doubleValue();
+                        int target = (int) Math.round(in.getRiskReward() * sl + offset);
+                        double potentialProfit = (optimal * tickValue * target) - (commission * optimal);
+                        double potentialLoss  = optimal * riskPerContract;
+
+                        ResultRowDTO row = new ResultRowDTO();
+                        row.getAsset().set(in.getMarket().getDescription());
+                        row.getBroker().set(in.getAccount().getDescription());
+                        row.getSymbol().set(symbol);
+                        row.getTarget().set(target);
+                        row.getSlSize().set(sl);
+                        row.getRiskPerContract().set(round(riskPerContract));
+                        row.getOptimalContract().set(optimal);
+                        row.getCapitalUsed().set(round(capitalUsed));
+                        row.getRealRisk().set(round(realRisk));
+                        row.getPotentialProfit().set(round(potentialProfit));
+                        row.getPotentialLoss().set(round(potentialLoss));
+                        row.getRiskPercentage().set(round(riskPctApplied));
+
+                        // Color a aplicar en columnas ticker/optimal contract
+                        String c1 = in.getMarket().getColor1();
+                        String c2 = in.getMarket().getColor2();
+                        String chosen = (symbol!=null && symbol.startsWith("M")) ? c1 : c2;
+                        row.getRowColor().set(chosen);
+
+                        results.add(row);
                     }
-
-                    double capitalUsed = optimal * riskPerContract;
-                    double realRisk = capitalUsed * 100.0 / in.getAccountSize().doubleValue();
-                    int target = (int) Math.round(in.getRiskReward() * sl + offset);
-                    double potentialProfit = (optimal * tickValue * target) - (commission * optimal);
-                    double potentialLoss  = optimal * riskPerContract;
-
-                    ResultRowDTO row = new ResultRowDTO();
-                    row.getAsset().set(in.getMarket().getDescription());
-                    row.getBroker().set(in.getAccount().getDescription());
-                    row.getSymbol().set(symbol);
-                    row.getTarget().set(target);
-                    row.getSlSize().set(sl);
-                    row.getRiskPerContract().set(round(riskPerContract));
-                    row.getOptimalContract().set(optimal);
-                    row.getCapitalUsed().set(round(capitalUsed));
-                    row.getRealRisk().set(round(realRisk));
-                    row.getPotentialProfit().set(round(potentialProfit));
-                    row.getPotentialLoss().set(round(potentialLoss));
-                    row.getRiskPercentage().set(round(riskPctApplied));
-
-                    // Color a aplicar en columnas ticker/optimal contract
-                    String c1 = in.getMarket().getColor1();
-                    String c2 = in.getMarket().getColor2();
-                    String chosen = (symbol!=null && symbol.startsWith("M")) ? c1 : c2;
-                    row.getRowColor().set(chosen);
-
-                    results.add(row);
                 }
             }
         }

--- a/src/test/java/com/cwdarmm/service/ExcelComparisonTest.java
+++ b/src/test/java/com/cwdarmm/service/ExcelComparisonTest.java
@@ -1,0 +1,77 @@
+package com.cwdarmm.service;
+
+import com.cwdarmm.model.domain.*;
+import com.cwdarmm.model.dto.ResultRowDTO;
+import com.cwdarmm.model.dto.RiskInputDTO;
+import com.cwdarmm.repository.BdMarketRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExcelComparisonTest {
+    @Test
+    void scenarioFromUser() {
+        BdMarket es = BdMarket.builder()
+                .id(1L)
+                .account(CatAccount.builder().id(1L).description("NEXGEN").build())
+                .market(CatMarket.builder().id(1L).description("S&P 500").color1("c1").color2("c2").build())
+                .marketData(CatMarketData.builder().id(1L).description("PROJECTX").build())
+                .contract(CatContract.builder().id(1L).description("E-mini S&P").build())
+                .symbol(CatSymbol.builder().id(1L).symbol("ES").build())
+                .tickValue(12.5)
+                .commission(2.08)
+                .build();
+        BdMarket mes = BdMarket.builder()
+                .id(2L)
+                .account(es.getAccount())
+                .market(es.getMarket())
+                .marketData(es.getMarketData())
+                .contract(CatContract.builder().id(2L).description("Micro E-mini S&P").build())
+                .symbol(CatSymbol.builder().id(2L).symbol("MES").build())
+                .tickValue(1.25)
+                .commission(0.74)
+                .build();
+
+        BdMarketRepository repo = Mockito.mock(BdMarketRepository.class);
+        Mockito.when(repo.findOneByMktAccMdata(1L,1L,1L)).thenReturn(List.of(es, mes));
+
+        OptimizationService svc = new OptimizationService(repo);
+
+        RiskInputDTO req = RiskInputDTO.builder()
+                .account(es.getAccount())
+                .market(es.getMarket())
+                .marketData(es.getMarketData())
+                .accountSize(new BigDecimal("200"))
+                .riskReward(2.0)
+                .ticksSl1(1)
+                .ticksSl2(1)
+                .house(false)
+                .lunch(true)
+                .win(true)
+                .firstTrade(false)
+                .riskPctB(new BigDecimal("1.5"))
+                .build();
+
+        List<ResultRowDTO> rows = svc.calculate(req);
+        assertEquals(4, rows.size());
+        // first row correspond to ES riskPct 1.575
+        ResultRowDTO row0 = rows.get(0);
+        assertEquals("S&P 500", row0.getAsset().get());
+        assertEquals("NEXGEN", row0.getBroker().get());
+        assertEquals("ES", row0.getSymbol().get());
+        assertEquals(3, row0.getTarget().get());
+        assertEquals(1, row0.getSlSize().get());
+        assertEquals(0, row0.getOptimalContract().get());
+        assertEquals(1.575, row0.getRiskPercentage().get());
+
+        ResultRowDTO row2 = rows.get(2); // MES riskPct 1.575
+        assertEquals("MES", row2.getSymbol().get());
+        assertEquals(1, row2.getOptimalContract().get());
+        assertEquals(1.99, row2.getRiskPerContract().get(), 0.01);
+        assertEquals(1.575, row2.getRiskPercentage().get());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `OptimizationService` computes scenarios for each active risk percentage (House and Lunch) instead of only Kelly A
- add regression test matching Excel scenario for S&P 500 and MES contracts

## Testing
- `mvn -q -e -Dtest=ExcelComparisonTest test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894280466cc832d8006c8232225bbb2