### PR TITLE
Fix risk calculations for initial trade and rounding

### DIFF
--- a/src/main/java/com/cwdarmm/service/OptimizationService.java
+++ b/src/main/java/com/cwdarmm/service/OptimizationService.java
@@ -89,9 +89,15 @@ public class OptimizationService {
         return rows;
     }
 
+    /** Redondea a un número arbitrario de decimales */
+    private double round(double v, int scale) {
+        double factor = Math.pow(10, scale);
+        return Math.round(v * factor) / factor;
+    }
+
     /** Redondea a 2 decimales */
     private double round(double v) {
-        return Math.round(v * 100.0) / 100.0;
+        return round(v, 2);
     }
 
     /**
@@ -179,7 +185,8 @@ public class OptimizationService {
                         row.getRealRisk().set(round(realRisk));
                         row.getPotentialProfit().set(round(potentialProfit));
                         row.getPotentialLoss().set(round(potentialLoss));
-                        row.getRiskPercentage().set(round(riskPctApplied));
+                        // El formulario original maneja el porcentaje de riesgo con 3 decimales
+                        row.getRiskPercentage().set(round(riskPctApplied, 3));
 
                         // Color a aplicar en columnas ticker/optimal contract
                         String c1 = in.getMarket().getColor1();

--- a/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
+++ b/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
@@ -218,6 +218,10 @@ public class RiskAnalysisService {
             // 3.b) Número óptimo de contratos = floor(currentRisk / riskPerContract)
             BigDecimal optContracts = currentRisk
                     .divide(riskPerContract, 0, BigDecimal.ROUND_DOWN);
+            // En el primer trade el VBA permite operar 5 contratos como arranque
+            if (firstTrade && optContracts.compareTo(BigDecimal.ONE) < 0) {
+                optContracts = BigDecimal.valueOf(5);
+            }
             log.debug("optContracts for sl {} = {}", sl, optContracts);
 
             // 3.c) Ticks objetivo en formato decimal.


### PR DESCRIPTION
## Summary
- Allow five contracts on first trade when account risk is insufficient
- Round risk percentages to three decimals to match VBA results

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68942f9943d0832db13db4d2e47879bc