### PR TITLE
Auto-run result calculations when selecting tab

### DIFF
--- a/src/main/java/com/cwdarmm/controller/MainWindowController.java
+++ b/src/main/java/com/cwdarmm/controller/MainWindowController.java
@@ -22,6 +22,7 @@ public class MainWindowController {
     @FXML private javafx.scene.control.Tab tabMarketDb;
 
     private final BdMarketController bdMarketController;
+    private final ResultViewController resultViewController;
 
     @FXML
     public void initialize() {
@@ -32,6 +33,13 @@ public class MainWindowController {
         tabMarketDb.setOnSelectionChanged(ev -> {
             if (tabMarketDb.isSelected()) {
                 bdMarketController.refreshTable();
+            }
+        });
+
+        // Al entrar a la pestaña Results recalculamos automáticamente
+        tabResults.setOnSelectionChanged(ev -> {
+            if (tabResults.isSelected()) {
+                resultViewController.onClick();
             }
         });
     }

--- a/src/main/java/com/cwdarmm/controller/ResultViewController.java
+++ b/src/main/java/com/cwdarmm/controller/ResultViewController.java
@@ -6,10 +6,8 @@ package com.cwdarmm.controller;
  */
 
 import com.cwdarmm.service.OptimizationService;
-import com.cwdarmm.service.MarketDataService;
 import com.cwdarmm.model.dto.ResultRowDTO;
 import com.cwdarmm.model.dto.RiskInputDTO;
-import com.cwdarmm.model.dto.MarketDTO;
 import com.cwdarmm.service.RiskContext;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
@@ -18,7 +16,6 @@ import javafx.stage.Stage;
 import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 
-import java.math.BigDecimal;
 import java.util.List;
 
 @Component
@@ -39,9 +36,9 @@ public class ResultViewController {
     @FXML private TableColumn<ResultRowDTO, Double> colLoss;
     @FXML private TableColumn<ResultRowDTO, Double> colRiskPct;
 
-    // Servicios que encapsulan la lógica de cálculo y el acceso a markets
+    // Servicios que encapsulan la lógica de cálculo y el acceso a la última
+    // selección de parámetros (RiskContext)
     private final OptimizationService optimizationService;
-    private final MarketDataService marketDataService;
     private final RiskContext riskContext;
     private Stage dialogStage;
 
@@ -97,22 +94,21 @@ public class ResultViewController {
      * almacenada en la base de datos como ejemplo sencillo.</p>
      */
     @FXML
-    private void onClick() {
-        // 1) Preferimos el request inyectado
+    public void onClick() {
+        // 1) Preferimos el request inyectado directamente por otro controlador
         RiskInputDTO req = this.request;
 
         // 2) Si no llegó, usamos el último guardado por Risk Manager
         if (req == null) req = riskContext.get();
 
-        // 3) Fallback opcional (coherente con tus capturas Excel)
+        // 3) Si sigue sin existir configuración mostramos un mensaje y salimos
         if (req == null) {
-            List<MarketDTO> markets = marketDataService.findAll();
-            if (markets.isEmpty()) {
-                new Alert(Alert.AlertType.INFORMATION, "No market sessions configured").showAndWait();
-                return;
-            }
-            MarketDTO m = markets.get(0);
+            new Alert(Alert.AlertType.INFORMATION,
+                    "No risk session configured").showAndWait();
+            return;
         }
+
+        // 4) Calcular y poblar la tabla
         List<ResultRowDTO> rows = optimizationService.calculate(req);
         tblResults.setItems(FXCollections.observableArrayList(rows));
     }

--- a/src/main/resources/fxml/ResultView.fxml
+++ b/src/main/resources/fxml/ResultView.fxml
@@ -31,7 +31,7 @@
     </TableView>
 
     <HBox spacing="8" alignment="CENTER_RIGHT">
-        <Button text="Click" onAction="#onClick"/>
+        <Button text="Recalculate" onAction="#onClick"/>
         <Button text="Close" onAction="#onClose"/>
     </HBox>
 </VBox>


### PR DESCRIPTION
## Summary
- Avoid null request crashes in ResultViewController by pulling the last risk session from context and warning when none exists.
- Automatically recompute results whenever the "Results" tab is selected, eliminating the need for manual clicks.
- Rename the manual action button to "Recalculate" for clarity.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68959d3381e0832da9ac9b1026b9e02a