### PR TITLE
Fix risk percentage and contract logic in results calculation

### DIFF
--- a/src/main/java/com/cwdarmm/service/OptimizationService.java
+++ b/src/main/java/com/cwdarmm/service/OptimizationService.java
@@ -68,13 +68,12 @@ public class OptimizationService {
         if (baseRiskPcts.isEmpty()) baseRiskPcts.add(BigDecimal.ZERO);
 
         for (BigDecimal basePctOrig : baseRiskPcts) {
+            // Los porcentajes recibidos ya vienen ajustados desde
+            // {@link RiskAnalysisService#calculate}.  No debemos volver
+            // a aplicar aquí el factor de compounding/drawdown, pues
+            // produciría un doble multiplicador y alteraría el
+            // Risk Percentage mostrado en Results.
             BigDecimal basePct = basePctOrig;
-
-            // Compounding/drawdown si NO es primer trade (igual que en Risk Manager)
-            if (!in.isFirstTrade()) {
-                BigDecimal mult = in.isWin() ? new BigDecimal("1.05") : new BigDecimal("0.98");
-                basePct = basePct.multiply(mult);
-            }
 
             double pctBase = basePct.doubleValue();
             double x = pctBase < 1.0 ? 0.03 : 0.10; // en tus capturas: 1.500% → 1.575% y 1.675%
@@ -97,6 +96,13 @@ public class OptimizationService {
                     int optimal = 0;
                     if (riskPerContract > 0) {
                         optimal = (int) Math.floor(currentRiskUSD / riskPerContract);
+                    }
+                    // Regla especial: en el primer trade el XLSM permite
+                    // operar 5 contratos si la división anterior produce
+                    // cero (riesgo insuficiente). Esta lógica afecta a
+                    // todas las columnas subsiguientes.
+                    if (in.isFirstTrade() && optimal < 1) {
+                        optimal = 5;
                     }
 
                     // Capital usado y métricas derivadas

--- a/src/test/java/com/cwdarmm/service/OptimizationServiceCalculateTest.java
+++ b/src/test/java/com/cwdarmm/service/OptimizationServiceCalculateTest.java
@@ -63,5 +63,54 @@ public class OptimizationServiceCalculateTest {
         assertEquals(3, row.getTarget().get()); // 1*1 + offset(2)
         assertEquals(5, row.getOptimalContract().get());
     }
+
+    /**
+     * The Risk Percentage passed to the service already contains the
+     * compounding from the previous trade. The service must not
+     * multiply it again; otherwise the displayed percentage would be
+     * inflated (e.g. 1.754 instead of 1.675).
+     */
+    @Test
+    void riskPercentageDoesNotDoubleCompound() {
+        BdMarket bd = BdMarket.builder()
+                .id(1L)
+                .account(CatAccount.builder().id(1L).description("NEXGEN").build())
+                .market(CatMarket.builder().id(1L).description("NASDAQ").build())
+                .marketData(CatMarketData.builder().id(1L).description("PROJECTX").build())
+                .contract(CatContract.builder().id(1L).description("E-mini NASDAQ").build())
+                .symbol(CatSymbol.builder().id(1L).symbol("NQ").build())
+                .tickValue(5.0)
+                .commission(1.0)
+                .build();
+
+        BdMarketRepository repo = Mockito.mock(BdMarketRepository.class);
+        Mockito.when(repo.findOneByMktAccMdata(1L,1L,1L))
+                .thenReturn(List.of(bd));
+
+        OptimizationService svc = new OptimizationService(repo);
+
+        // riskPctA ya viene con el compounding aplicado (1.575%)
+        RiskInputDTO req = RiskInputDTO.builder()
+                .account(bd.getAccount())
+                .market(bd.getMarket())
+                .marketData(bd.getMarketData())
+                .accountSize(new BigDecimal("10000"))
+                .riskReward(2.0)
+                .ticksSl1(10)
+                .house(true)
+                .firstTrade(false)
+                .win(true) // no debe influir
+                .riskPctA(new BigDecimal("1.575"))
+                .build();
+
+        List<ResultRowDTO> rows = svc.calculate(req);
+        assertEquals(2, rows.size());
+
+        ResultRowDTO base = rows.get(0); // base percentage
+        ResultRowDTO withX = rows.get(1); // base + X
+
+        assertEquals(1.575, base.getRiskPercentage().get(), 1e-3);
+        assertEquals(1.675, withX.getRiskPercentage().get(), 1e-3);
+    }
 }
 


### PR DESCRIPTION
## Summary
- avoid double compounding when building Results table
- default to five contracts on first trade when risk is insufficient
- cover risk percentage calculation with unit test

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ab6a0f378832d9b939cfd634ba676