### PR TITLE
feat: add bilingual support

### DIFF
--- a/src/main/java/com/cwdarmm/MainApp.java
+++ b/src/main/java/com/cwdarmm/MainApp.java
@@ -39,7 +39,7 @@ public class MainApp extends Application {
         Scene scene = new Scene(root);
         scene.getStylesheets().add(getClass().getResource("/styles/styles.css").toExternalForm());
 
-        primaryStage.setTitle("CW-DARMM - Market Manager");
+        primaryStage.setTitle(fxmlLoader.getResources().getString("app.title"));
         primaryStage.setScene(scene);
         primaryStage.show();
     }

--- a/src/main/java/com/cwdarmm/config/SpringFXMLLoader.java
+++ b/src/main/java/com/cwdarmm/config/SpringFXMLLoader.java
@@ -11,17 +11,29 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Locale;
+import java.util.ResourceBundle;
 
 @Component
 public class SpringFXMLLoader {
     private final ApplicationContext context;
+    private Locale locale = Locale.ENGLISH;
 
     public SpringFXMLLoader(ApplicationContext context) {
         this.context = context;
     }
 
+    public void setLocale(Locale locale) {
+        this.locale = locale;
+    }
+
+    public Locale getLocale() {
+        return locale;
+    }
+
     public FXMLLoader load(String fxmlPath) throws IOException {
-        FXMLLoader loader = new FXMLLoader(getClass().getResource(fxmlPath));
+        ResourceBundle bundle = ResourceBundle.getBundle("i18n.messages", locale);
+        FXMLLoader loader = new FXMLLoader(getClass().getResource(fxmlPath), bundle);
         loader.setControllerFactory(context::getBean);
         loader.load();
         return loader;

--- a/src/main/java/com/cwdarmm/controller/MainWindowController.java
+++ b/src/main/java/com/cwdarmm/controller/MainWindowController.java
@@ -6,10 +6,17 @@ package com.cwdarmm.controller;
  */
 
 import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.MenuButton;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.Tab;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Locale;
 
 @Component
 @RequiredArgsConstructor
@@ -20,9 +27,11 @@ public class MainWindowController {
 
     @FXML private javafx.scene.control.Tab tabResults;
     @FXML private javafx.scene.control.Tab tabMarketDb;
+    @FXML private MenuButton btnLanguage;
 
     private final BdMarketController bdMarketController;
     private final ResultViewController resultViewController;
+    private final SpringFXMLLoader springFXMLLoader;
 
     @FXML
     public void initialize() {
@@ -48,5 +57,24 @@ public class MainWindowController {
 
     public void showResultsTab() {
         tabPane.getSelectionModel().select(tabResults);
+    }
+
+    @FXML
+    private void switchToSpanish() throws IOException {
+        reload(new Locale("es"));
+    }
+
+    @FXML
+    private void switchToEnglish() throws IOException {
+        reload(Locale.ENGLISH);
+    }
+
+    private void reload(Locale locale) throws IOException {
+        springFXMLLoader.setLocale(locale);
+        FXMLLoader loader = springFXMLLoader.load("/fxml/MainWindow.fxml");
+        Parent root = loader.getRoot();
+        Scene scene = btnLanguage.getScene();
+        scene.setRoot(root);
+        scene.getWindow().setTitle(loader.getResources().getString("app.title"));
     }
 }

--- a/src/main/java/com/cwdarmm/controller/MarketManagerController.java
+++ b/src/main/java/com/cwdarmm/controller/MarketManagerController.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import java.util.ResourceBundle;
 
 /**
  * Controlador de la vista principal de mercados.
@@ -59,6 +60,7 @@ public class MarketManagerController {
     @FXML
     private TableColumn<MarketDTO, Double> colFinalLunch;
     @FXML private TableColumn<MarketDTO, Void> colActions;
+    @FXML private ResourceBundle resources;
 
 
     private MarketDTO lastSaved;
@@ -126,7 +128,7 @@ public class MarketManagerController {
             Stage openStage = new Stage();
             openStage.initOwner(tableMarkets.getScene().getWindow());
             openStage.initModality(Modality.WINDOW_MODAL);     // WINDOW_MODAL en lugar de APPLICATION_MODAL
-            openStage.setTitle("Open Market");
+            openStage.setTitle(resources.getString("stage.openmarket"));
             openStage.setScene(new Scene(openLoader.getRoot()));
 
             // 2) Configura callback para guardar el DTO y recargar la tabla
@@ -147,7 +149,7 @@ public class MarketManagerController {
                 Stage riskStage = new Stage();
                 riskStage.initOwner(tableMarkets.getScene().getWindow());
                 riskStage.initModality(Modality.NONE);
-                riskStage.setTitle(lastSaved.getMarket().getDescription() + " – Risk Manager");
+                riskStage.setTitle(lastSaved.getMarket().getDescription() + " – " + resources.getString("risk.dashboard.window"));
                 riskStage.setScene(new Scene(riskLoader.getRoot()));
 
                 MarketRiskDashboardController rtc = riskLoader.getController();
@@ -171,7 +173,7 @@ public class MarketManagerController {
             Stage riskStage = new Stage();
             riskStage.initOwner(tableMarkets.getScene().getWindow());
             riskStage.initModality(Modality.NONE);
-            riskStage.setTitle(context.getMarket().getDescription() + " – Risk Manager");
+            riskStage.setTitle(context.getMarket().getDescription() + " – " + resources.getString("risk.dashboard.window"));
             riskStage.setScene(new Scene(riskLoader.getRoot()));
 
             // 2) Pasa el contexto al controller de Risk Table
@@ -222,7 +224,7 @@ public class MarketManagerController {
             Stage dialog = new Stage();
             dialog.initOwner(tableMarkets.getScene().getWindow());
             dialog.initModality(Modality.WINDOW_MODAL);
-            dialog.setTitle("Editar Market");
+            dialog.setTitle(resources.getString("stage.editmarket"));
             dialog.setScene(new Scene(loader.getRoot()));
 
             OpenMarketSessionController omc = loader.getController();
@@ -242,7 +244,7 @@ public class MarketManagerController {
     // Método de borrado con confirmación
     private void onDeleteMarket(MarketDTO dto) {
         Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
-                "¿Eliminar este market?", ButtonType.YES, ButtonType.NO);
+                resources.getString("alert.delete.market"), ButtonType.YES, ButtonType.NO);
         Optional<ButtonType> res = confirm.showAndWait();
         if (res.orElse(ButtonType.NO) == ButtonType.YES) {
             marketDataService.delete(dto.getId());  // necesitas este método en tu servicio

--- a/src/main/java/com/cwdarmm/controller/MarketRiskDashboardController.java
+++ b/src/main/java/com/cwdarmm/controller/MarketRiskDashboardController.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.ResourceBundle;
 
 @Component
 @RequiredArgsConstructor
@@ -45,6 +46,7 @@ public class MarketRiskDashboardController {
     @FXML private TableColumn<RiskResultDTO,Double>  colRiskA;
     @FXML private TableColumn<RiskResultDTO,Double>  colRiskB;
     @FXML private Button btnExportCsv;
+    @FXML private ResourceBundle resources;
 
     private final OutputService outputService;
     private final SpringFXMLLoader springFXMLLoader;
@@ -113,10 +115,10 @@ public class MarketRiskDashboardController {
                 var list = tableResults.getItems();
                 Path file = Path.of(System.getProperty("user.home"), "risk-results.csv");
                 outputService.exportRiskResultsToCsv(list, file);
-                new Alert(Alert.AlertType.INFORMATION, "CSV exportado en:\n" + file)
+                new Alert(Alert.AlertType.INFORMATION, resources.getString("alert.csv.exported") + "\n" + file)
                         .showAndWait();
             } catch (IOException e) {
-                new Alert(Alert.AlertType.ERROR, "Error al exportar CSV:\n" + e.getMessage())
+                new Alert(Alert.AlertType.ERROR, resources.getString("alert.csv.error") + "\n" + e.getMessage())
                         .showAndWait();
             }
         });
@@ -147,7 +149,7 @@ public class MarketRiskDashboardController {
         });
         dialog.initOwner(tableResults.getScene().getWindow());
         dialog.initModality(Modality.APPLICATION_MODAL);
-        dialog.setTitle(context.getMarket().getDescription() + " – Risk Manager");
+        dialog.setTitle(context.getMarket().getDescription() + " – " + resources.getString("risk.dashboard.window"));
         dialog.setScene(new Scene(loader.getRoot()));
         dialog.showAndWait();
     }

--- a/src/main/java/com/cwdarmm/controller/OpenMarketSessionController.java
+++ b/src/main/java/com/cwdarmm/controller/OpenMarketSessionController.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Component;
  */
 
 import java.math.BigDecimal;
+import java.util.ResourceBundle;
 
 @Component
 @RequiredArgsConstructor
@@ -53,6 +54,7 @@ public class OpenMarketSessionController {
     private TextField tfRiskA;
     @FXML
     private TextField tfRiskB;
+    @FXML private ResourceBundle resources;
 
     @FXML
     public void initialize() {
@@ -172,7 +174,7 @@ public class OpenMarketSessionController {
 
     private boolean validateInputs() {
         if (cbAccount.getValue() == null || cbMarket.getValue() == null || cbMarketData.getValue() == null) {
-            showAlert(Alert.AlertType.WARNING, "Debe seleccionar Account, Market y Market Data.");
+            showAlert(Alert.AlertType.WARNING, resources.getString("alert.openmarket.missing"));
             return false;
         }
         try {
@@ -181,7 +183,7 @@ public class OpenMarketSessionController {
             double b = Double.parseDouble(tfRiskB.getText());
             if (size <= 0 || a <= 0 || b <= 0) throw new NumberFormatException();
         } catch (NumberFormatException ex) {
-            showAlert(Alert.AlertType.WARNING, "Account Size, Risk A y Risk B deben ser números mayores a cero.");
+            showAlert(Alert.AlertType.WARNING, resources.getString("alert.openmarket.number"));
             return false;
         }
         return true;
@@ -190,7 +192,7 @@ public class OpenMarketSessionController {
     private void showAlert(Alert.AlertType type, String message) {
         Alert alert = new Alert(type);
         alert.initOwner(dialogStage);
-        alert.setTitle("Validación");
+        alert.setTitle(resources.getString("alert.validation"));
         alert.setHeaderText(null);
         alert.setContentText(message);
         alert.showAndWait();

--- a/src/main/java/com/cwdarmm/controller/ResultViewController.java
+++ b/src/main/java/com/cwdarmm/controller/ResultViewController.java
@@ -16,6 +16,8 @@ import javafx.stage.Stage;
 import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 
+import java.util.ResourceBundle;
+
 import java.util.List;
 
 @Component
@@ -41,6 +43,8 @@ public class ResultViewController {
     private final OptimizationService optimizationService;
     private final RiskContext riskContext;
     private Stage dialogStage;
+
+    @FXML private ResourceBundle resources;
 
     private RiskInputDTO request;
 
@@ -104,7 +108,7 @@ public class ResultViewController {
         // 3) Si sigue sin existir configuración mostramos un mensaje y salimos
         if (req == null) {
             new Alert(Alert.AlertType.INFORMATION,
-                    "No risk session configured").showAndWait();
+                    resources.getString("alert.norisk")).showAndWait();
             return;
         }
 

--- a/src/main/java/com/cwdarmm/controller/RiskConfigController.java
+++ b/src/main/java/com/cwdarmm/controller/RiskConfigController.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.ResourceBundle;
 import java.util.function.Consumer;
 
 @Component
@@ -78,7 +79,8 @@ public class RiskConfigController {
     private CheckBox chkLoss;
     @FXML
     private ImageView imgCoins;
-
+    @FXML
+    private ResourceBundle resources;
     @FXML
     public void initialize() {
         // 1) Cargamos cuentas
@@ -214,14 +216,14 @@ public class RiskConfigController {
                     marketContext.getMarket().getDescription() + ".xml");
             exportService.exportStrategyToXml(marketContext, rows, xml);
             new Alert(Alert.AlertType.INFORMATION,
-                    "XML generado en:\n" + xml).showAndWait();
+                    resources.getString("alert.xmlgenerated") + "\n" + xml).showAndWait();
         }
         if (doAhk) {
             Path ahk = Path.of(System.getProperty("user.home"),
                     marketContext.getMarket().getDescription() + ".ahk");
             exportService.exportStrategyToAhk(marketContext, rows, ahk);
             new Alert(Alert.AlertType.INFORMATION,
-                    "AHK generado en:\n" + ahk).showAndWait();
+                    resources.getString("alert.ahkgenerated") + "\n" + ahk).showAndWait();
         }
 
         // 7) Refrescar tabla (tu callback monta estas filas en la TableView)
@@ -248,7 +250,7 @@ public class RiskConfigController {
             popup.initOwner(dialogStage.getOwner());
         }
         popup.initModality(Modality.NONE);
-        popup.setTitle(criteriaAccount + " – Optimal Contracts");
+        popup.setTitle(criteriaAccount + " – " + resources.getString("optimal.contracts.window"));
         popup.setScene(new Scene(loader.getRoot()));
         popup.show();
     }
@@ -290,15 +292,15 @@ public class RiskConfigController {
 
     private boolean validate() {
         if (cbRiskAccount.getValue() == null || cbRiskMarket.getValue() == null || cbRiskMarketData.getValue() == null) {
-            alert("Selecciona Account, Market y Market Data.");
+            alert(resources.getString("alert.select.market"));
             return false;
         }
         if (!chkHouse.isSelected() && !chkLunch.isSelected()) {
-            alert("Selecciona al menos HOUSE o LUNCH.");
+            alert(resources.getString("alert.select.session"));
             return false;
         }
         if (!chkWin.isSelected() && !chkLoss.isSelected()) {
-            alert("Selecciona al menos WIN o LOSS.");
+            alert(resources.getString("alert.select.result"));
             return false;
         }
         try {
@@ -307,7 +309,7 @@ public class RiskConfigController {
                     Integer.parseInt(tfTicksSl1.getText()) <= 0 ||
                     Integer.parseInt(tfTicksSl2.getText()) <= 0) throw new Exception();
         } catch (Exception e) {
-            alert("Revisa los valores numéricos.");
+            alert(resources.getString("alert.check.values"));
             return false;
         }
         return true;
@@ -316,7 +318,7 @@ public class RiskConfigController {
     private void alert(String msg) {
         Alert a = new Alert(Alert.AlertType.WARNING);
         a.initOwner(dialogStage);
-        a.setTitle("Validación");
+        a.setTitle(resources.getString("alert.validation"));
         a.setHeaderText(null);
         a.setContentText(msg);
         a.showAndWait();

--- a/src/main/resources/fxml/MainWindow.fxml
+++ b/src/main/resources/fxml/MainWindow.fxml
@@ -1,22 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.MenuButton?>
+<?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.control.TabPane?>
+<?import javafx.scene.control.ToolBar?>
 <?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.HBox?>
 
 <BorderPane xmlns:fx="http://javafx.com/fxml"
             fx:controller="com.cwdarmm.controller.MainWindowController">
+    <top>
+        <ToolBar>
+            <Pane fx:id="spacer" HBox.hgrow="ALWAYS"/>
+            <MenuButton fx:id="btnLanguage" text="%button.language">
+                <items>
+                    <MenuItem text="%lang.es" onAction="#switchToSpanish"/>
+                    <MenuItem text="%lang.en" onAction="#switchToEnglish"/>
+                </items>
+            </MenuButton>
+        </ToolBar>
+    </top>
     <center>
         <TabPane fx:id="tabPane">
             <!-- Tab existente de Markets -->
-            <Tab text="Markets" fx:id="tabMarkets">
+            <Tab text="%tab.markets" fx:id="tabMarkets">
                 <fx:include source="MarketManagerView.fxml"/>
             </Tab>
             <!-- NUEVO: Resultados -->
-            <Tab text="Results" fx:id="tabResults">
+            <Tab text="%tab.results" fx:id="tabResults">
                 <fx:include source="ResultView.fxml"/>
             </Tab>
             <!-- NUEVO: BD_Market -->
-            <Tab text="Market DB" fx:id="tabMarketDb">
+            <Tab text="%tab.marketdb" fx:id="tabMarketDb">
                 <fx:include source="MarketDbView.fxml"/>
             </Tab>
         </TabPane>

--- a/src/main/resources/fxml/MarketDbView.fxml
+++ b/src/main/resources/fxml/MarketDbView.fxml
@@ -11,25 +11,25 @@
         <Insets top="16" right="16" bottom="16" left="16"/>
     </padding>
 
-    <Label text="BD_MARKET" style="-fx-font-size:16px; -fx-font-weight:bold;"/>
+<Label text="%market.db.title" style="-fx-font-size:16px; -fx-font-weight:bold;"/>
 
     <TableView fx:id="tblMarketDb" prefHeight="400">
         <columns>
-            <TableColumn text="Future"        fx:id="colFuture"/>
-            <TableColumn text="Account"       fx:id="colAccount"/>
-            <TableColumn text="Market Data"   fx:id="colMarketData"/>
-            <TableColumn text="Name"          fx:id="colName"/>
-            <TableColumn text="Symbol"        fx:id="colSymbol"/>
-            <TableColumn text="Multiplier"    fx:id="colMultiplier"/>
-            <TableColumn text="Tick Size"     fx:id="colTickSize"/>
-            <TableColumn text="Tick Value"    fx:id="colTickValue"/>
-            <TableColumn text="Margin"        fx:id="colMargin"/>
-            <TableColumn text="Commission"    fx:id="colCommission"/>
+            <TableColumn text="%market.db.future"        fx:id="colFuture"/>
+            <TableColumn text="%market.db.account"       fx:id="colAccount"/>
+            <TableColumn text="%market.db.marketdata"   fx:id="colMarketData"/>
+            <TableColumn text="%market.db.name"          fx:id="colName"/>
+            <TableColumn text="%market.db.symbol"        fx:id="colSymbol"/>
+            <TableColumn text="%market.db.multiplier"    fx:id="colMultiplier"/>
+            <TableColumn text="%market.db.ticksize"     fx:id="colTickSize"/>
+            <TableColumn text="%market.db.tickvalue"    fx:id="colTickValue"/>
+            <TableColumn text="%market.db.margin"        fx:id="colMargin"/>
+            <TableColumn text="%market.db.commission"    fx:id="colCommission"/>
         </columns>
     </TableView>
 
     <HBox spacing="8" alignment="CENTER_RIGHT">
-        <Button text="Refresh"    onAction="#onRefresh"/>
-        <Button text="Close"      onAction="#onClose"/>
+        <Button text="%market.db.refresh"    onAction="#onRefresh"/>
+        <Button text="%market.db.close"      onAction="#onClose"/>
     </HBox>
 </VBox>

--- a/src/main/resources/fxml/MarketManagerView.fxml
+++ b/src/main/resources/fxml/MarketManagerView.fxml
@@ -5,8 +5,8 @@
 <BorderPane fx:id="root" xmlns:fx="http://javafx.com/fxml" fx:controller="com.cwdarmm.controller.MarketManagerController">
     <top>
         <ToolBar>
-            <Label text="Markets" style="-fx-font-size: 18px; -fx-font-weight: bold;"/>
-            <Button text="Open Market" onAction="#onOpenMarket"/>
+            <Label text="%market.manager.header" style="-fx-font-size: 18px; -fx-font-weight: bold;"/>
+            <Button text="%market.manager.open" onAction="#onOpenMarket"/>
         </ToolBar>
     </top>
     <center>
@@ -19,49 +19,49 @@
                     </cellValueFactory>
                 </TableColumn>
 
-                <TableColumn fx:id="colAccount" text="Account">
+                <TableColumn fx:id="colAccount" text="%market.manager.account">
                     <cellValueFactory>
                         <PropertyValueFactory property="account.name"/>
                     </cellValueFactory>
                 </TableColumn>
-                <TableColumn fx:id="colMarket" text="Market">
+                <TableColumn fx:id="colMarket" text="%market.manager.market">
                     <cellValueFactory>
                         <PropertyValueFactory property="market.name"/>
                     </cellValueFactory>
                 </TableColumn>
-                <TableColumn fx:id="colMarketData" text="Market Data">
+                <TableColumn fx:id="colMarketData" text="%market.manager.marketdata">
                     <cellValueFactory>
                         <PropertyValueFactory property="marketData.name"/>
                     </cellValueFactory>
                 </TableColumn>
 
-                <TableColumn fx:id="colSize" text="Account Size" prefWidth="100">
+                <TableColumn fx:id="colSize" text="%market.manager.accountsize" prefWidth="100">
                     <cellValueFactory>
                         <PropertyValueFactory property="accountSize"/>
                     </cellValueFactory>
                 </TableColumn>
 
-                <TableColumn fx:id="colRiskA" text="Risk A">
+                <TableColumn fx:id="colRiskA" text="%market.manager.riska">
                     <cellValueFactory>
                         <PropertyValueFactory property="riskA"/>
                     </cellValueFactory>
                 </TableColumn>
-                <TableColumn fx:id="colRiskB" text="Risk B">
+                <TableColumn fx:id="colRiskB" text="%market.manager.riskb">
                     <cellValueFactory>
                         <PropertyValueFactory property="riskB"/>
                     </cellValueFactory>
                 </TableColumn>
-                <TableColumn fx:id="colFinalHouse" text="Final House">
+                <TableColumn fx:id="colFinalHouse" text="%market.manager.finalhouse">
                     <cellValueFactory>
                         <PropertyValueFactory property="riskFinalHouse"/>
                     </cellValueFactory>
                 </TableColumn>
-                <TableColumn fx:id="colFinalLunch" text="Final Lunch">
+                <TableColumn fx:id="colFinalLunch" text="%market.manager.finallunch">
                     <cellValueFactory>
                         <PropertyValueFactory property="riskFinalLunch"/>
                     </cellValueFactory>
                 </TableColumn>
-                <TableColumn fx:id="colActions" text="Acciones" prefWidth="80"/>
+                <TableColumn fx:id="colActions" text="%market.manager.actions" prefWidth="80"/>
 
             </columns>
         </TableView>

--- a/src/main/resources/fxml/MarketRiskDashboard.fxml
+++ b/src/main/resources/fxml/MarketRiskDashboard.fxml
@@ -12,23 +12,23 @@
     <!-- Top: Título y botón Risk Manage -->
     <top>
         <ToolBar>
-            <Label text="Risk Manager: " style="-fx-font-size:16px; -fx-font-weight:bold;"/>
+            <Label text="%risk.dashboard.titleprefix" style="-fx-font-size:16px; -fx-font-weight:bold;"/>
             <Label fx:id="lblContext" />
             <Pane HBox.hgrow="ALWAYS" />
-            <Button text="Risk Manage" onAction="#onRiskManage" />
+            <Button text="%risk.dashboard.manage" onAction="#onRiskManage" />
         </ToolBar>
     </top>
     <!-- Center: TableView de resultados -->
     <center>
         <TableView fx:id="tableResults">
             <columns>
-                <TableColumn fx:id="colTrade" text="# Trade"/>
-                <TableColumn fx:id="colWl"       text="W/L"/>
-                <TableColumn fx:id="colAccount"  text="Account"/>
-                <TableColumn fx:id="colMarketData" text="Market Data"/>
-                <TableColumn fx:id="colAccountSize" text="Account Size"/>
-                <TableColumn fx:id="colRiskA"    text="Risk Kelly A"/>
-                <TableColumn fx:id="colRiskB"    text="Risk Kelly B"/>
+                <TableColumn fx:id="colTrade" text="%risk.dashboard.trade"/>
+                <TableColumn fx:id="colWl"       text="%risk.dashboard.wl"/>
+                <TableColumn fx:id="colAccount"  text="%risk.dashboard.account"/>
+                <TableColumn fx:id="colMarketData" text="%risk.dashboard.marketdata"/>
+                <TableColumn fx:id="colAccountSize" text="%risk.dashboard.accountsize"/>
+                <TableColumn fx:id="colRiskA"    text="%risk.dashboard.riska"/>
+                <TableColumn fx:id="colRiskB"    text="%risk.dashboard.riskb"/>
             </columns>
         </TableView>
     </center>
@@ -38,8 +38,8 @@
             <padding>
                 <Insets top="8" right="8" bottom="8" left="8"/>
             </padding>
-            <Button fx:id="btnExportCsv" text="Export CSV"/>
-            <Button text="Close" onAction="#onClose" />
+            <Button fx:id="btnExportCsv" text="%risk.dashboard.export"/>
+            <Button text="%risk.dashboard.close" onAction="#onClose" />
         </HBox>
     </bottom>
 </BorderPane>

--- a/src/main/resources/fxml/OpenMarketSessionForm.fxml
+++ b/src/main/resources/fxml/OpenMarketSessionForm.fxml
@@ -13,7 +13,7 @@
         <Insets top="16" right="16" bottom="16" left="16"/>
     </padding>
 
-    <Label text="MARKET" style="-fx-font-size: 16px; -fx-font-weight: bold;"/>
+    <Label text="%open.market.title" style="-fx-font-size: 16px; -fx-font-weight: bold;"/>
 
     <GridPane hgap="8" vgap="8">
         <columnConstraints>
@@ -30,32 +30,32 @@
         </rowConstraints>
 
         <!-- Account ComboBox ahora enlazado a CatAccount -->
-        <Label text="Account:" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
+        <Label text="%open.market.account" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
         <ComboBox fx:id="cbAccount"
                   GridPane.rowIndex="0" GridPane.columnIndex="1"/>
 
         <!-- Market ComboBox: CatMarket -->
-        <Label text="Market:" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
+        <Label text="%open.market.market" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
         <ComboBox fx:id="cbMarket"
                   GridPane.rowIndex="1" GridPane.columnIndex="1"/>
 
         <!-- Market Data ComboBox: CatMarketData -->
-        <Label text="Market Data:" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
+        <Label text="%open.market.marketdata" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
         <ComboBox fx:id="cbMarketData"
                   GridPane.rowIndex="2" GridPane.columnIndex="1"/>
 
-        <Label text="Account Size:" GridPane.rowIndex="3" GridPane.columnIndex="0"/>
+        <Label text="%open.market.accountsize" GridPane.rowIndex="3" GridPane.columnIndex="0"/>
         <TextField fx:id="tfAccountSize" GridPane.rowIndex="3" GridPane.columnIndex="1"/>
 
-        <Label text="Risk % A:" GridPane.rowIndex="4" GridPane.columnIndex="0"/>
+        <Label text="%open.market.riska" GridPane.rowIndex="4" GridPane.columnIndex="0"/>
         <TextField fx:id="tfRiskA" GridPane.rowIndex="4" GridPane.columnIndex="1"/>
 
-        <Label text="Risk % B:" GridPane.rowIndex="5" GridPane.columnIndex="0"/>
+        <Label text="%open.market.riskb" GridPane.rowIndex="5" GridPane.columnIndex="0"/>
         <TextField fx:id="tfRiskB" GridPane.rowIndex="5" GridPane.columnIndex="1"/>
     </GridPane>
 
     <HBox spacing="8" alignment="CENTER_RIGHT">
-        <Button fx:id="btnOpen" text="Open Market" onAction="#onOpenMarket"/>
-        <Button fx:id="btnClose" text="Close" onAction="#onClose"/>
+        <Button fx:id="btnOpen" text="%open.market.open" onAction="#onOpenMarket"/>
+        <Button fx:id="btnClose" text="%open.market.close" onAction="#onClose"/>
     </HBox>
 </VBox>

--- a/src/main/resources/fxml/OptimalContractsView.fxml
+++ b/src/main/resources/fxml/OptimalContractsView.fxml
@@ -16,10 +16,10 @@
     <center>
         <TableView fx:id="tblOptimal">
             <columns>
-                <TableColumn fx:id="colSlSize"   text="SL Size (Ticks)" />
-                <TableColumn fx:id="colTicker"   text="FUTURES TICKER" />
-                <TableColumn fx:id="colOptimal"  text="Optimal Contract" />
-                <TableColumn fx:id="colTarget"   text="Target (Ticks)" />
+                <TableColumn fx:id="colSlSize"   text="%optimal.contracts.slsize" />
+                <TableColumn fx:id="colTicker"   text="%optimal.contracts.ticker" />
+                <TableColumn fx:id="colOptimal"  text="%optimal.contracts.optimal" />
+                <TableColumn fx:id="colTarget"   text="%optimal.contracts.target" />
             </columns>
         </TableView>
     </center>

--- a/src/main/resources/fxml/ResultView.fxml
+++ b/src/main/resources/fxml/ResultView.fxml
@@ -11,27 +11,27 @@
         <Insets top="16" right="16" bottom="16" left="16"/>
     </padding>
 
-    <Label text="Optimization Results" style="-fx-font-size:16px; -fx-font-weight:bold;"/>
+    <Label text="%result.view.title" style="-fx-font-size:16px; -fx-font-weight:bold;"/>
 
     <TableView fx:id="tblResults" prefHeight="400">
         <columns>
-            <TableColumn text="Asset"               fx:id="colAsset"/>
-            <TableColumn text="Broker"              fx:id="colBroker"/>
-            <TableColumn text="Asset Symbol"        fx:id="colSymbol"/>
-            <TableColumn text="Target"              fx:id="colTarget"/>
-            <TableColumn text="SL Size"             fx:id="colSlSize"/>
-            <TableColumn text="Risk/Contract"       fx:id="colRiskPerContract"/>
-            <TableColumn text="Optimal Contract"    fx:id="colOptimalContract"/>
-            <TableColumn text="Total Capital Used"  fx:id="colCapitalUsed"/>
-            <TableColumn text="Real Risk"           fx:id="colRealRisk"/>
-            <TableColumn text="Potential Profit"    fx:id="colProfit"/>
-            <TableColumn text="Potential Loss"      fx:id="colLoss"/>
-            <TableColumn text="Risk Percentage"     fx:id="colRiskPct"/>
+            <TableColumn text="%result.view.asset"               fx:id="colAsset"/>
+            <TableColumn text="%result.view.broker"              fx:id="colBroker"/>
+            <TableColumn text="%result.view.assetsymbol"        fx:id="colSymbol"/>
+            <TableColumn text="%result.view.target"              fx:id="colTarget"/>
+            <TableColumn text="%result.view.slsize"             fx:id="colSlSize"/>
+            <TableColumn text="%result.view.riskpercontract"       fx:id="colRiskPerContract"/>
+            <TableColumn text="%result.view.optimalcontract"    fx:id="colOptimalContract"/>
+            <TableColumn text="%result.view.capitalused"  fx:id="colCapitalUsed"/>
+            <TableColumn text="%result.view.realrisk"           fx:id="colRealRisk"/>
+            <TableColumn text="%result.view.profit"    fx:id="colProfit"/>
+            <TableColumn text="%result.view.loss"      fx:id="colLoss"/>
+            <TableColumn text="%result.view.riskpct"     fx:id="colRiskPct"/>
         </columns>
     </TableView>
 
     <HBox spacing="8" alignment="CENTER_RIGHT">
-        <Button text="Recalculate" onAction="#onClick"/>
-        <Button text="Close" onAction="#onClose"/>
+        <Button text="%result.view.recalculate" onAction="#onClick"/>
+        <Button text="%result.view.close" onAction="#onClose"/>
     </HBox>
 </VBox>

--- a/src/main/resources/fxml/RiskConfigForm.fxml
+++ b/src/main/resources/fxml/RiskConfigForm.fxml
@@ -7,7 +7,7 @@
     <!-- Top: Título de la pestaña, puede incluir icono -->
     <top>
         <ToolBar>
-            <Label text="RISK MANAGER" style="-fx-font-size:18px; -fx-font-weight:bold;"/>
+            <Label text="%risk.config.title" style="-fx-font-size:18px; -fx-font-weight:bold;"/>
         </ToolBar>
     </top>
 
@@ -23,44 +23,44 @@
                     <ColumnConstraints percentWidth="70"/>
                 </columnConstraints>
                 <!-- Step 1,2,3 -->
-                <Label text="Step 1 – Account:" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
+                <Label text="%risk.config.step1" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
                 <ComboBox fx:id="cbRiskAccount" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
 
-                <Label text="Step 2 – Market:" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
+                <Label text="%risk.config.step2" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
                 <ComboBox fx:id="cbRiskMarket" GridPane.rowIndex="1" GridPane.columnIndex="1"/>
 
-                <Label text="Step 3 – Market Data:" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
+                <Label text="%risk.config.step3" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
                 <ComboBox fx:id="cbRiskMarketData" GridPane.rowIndex="2" GridPane.columnIndex="1"/>
 
                 <!-- Parámetros de riesgo -->
-                <Label text="Account Size:" GridPane.rowIndex="3" GridPane.columnIndex="0"/>
+                <Label text="%risk.config.accountsize" GridPane.rowIndex="3" GridPane.columnIndex="0"/>
                 <TextField fx:id="tfRiskAccountSize" GridPane.rowIndex="3" GridPane.columnIndex="1"/>
 
-                <Label text="Risk to Reward:" GridPane.rowIndex="4" GridPane.columnIndex="0"/>
+                <Label text="%risk.config.risktoreward" GridPane.rowIndex="4" GridPane.columnIndex="0"/>
                 <TextField fx:id="tfRiskReward" GridPane.rowIndex="4" GridPane.columnIndex="1"/>
 
-                <Label text="SL Size (Ticks):" GridPane.rowIndex="5" GridPane.columnIndex="0"/>
+                <Label text="%risk.config.slsize" GridPane.rowIndex="5" GridPane.columnIndex="0"/>
                 <HBox spacing="8" GridPane.rowIndex="5" GridPane.columnIndex="1">
                     <TextField fx:id="tfTicksSl1" prefWidth="60"/>
                     <TextField fx:id="tfTicksSl2" prefWidth="60"/>
                 </HBox>
 
-                <Label text="Stop Loss Size:" GridPane.rowIndex="6" GridPane.columnIndex="0"/>
+                <Label text="%risk.config.stoplosssize" GridPane.rowIndex="6" GridPane.columnIndex="0"/>
                 <TextField fx:id="tfStopLossSize" GridPane.rowIndex="6" GridPane.columnIndex="1"/>
 
                 <!-- Sesiones -->
                 <HBox spacing="16" GridPane.rowIndex="7" GridPane.columnIndex="1">
-                    <CheckBox fx:id="chkHouse" text="HOUSE"/>
-                    <CheckBox fx:id="chkLunch" text="LUNCH"/>
-                    <CheckBox fx:id="chkWin" text="WIN"/>
-                    <CheckBox fx:id="chkLoss" text="LOSS"/>
+                    <CheckBox fx:id="chkHouse" text="%risk.config.house"/>
+                    <CheckBox fx:id="chkLunch" text="%risk.config.lunch"/>
+                    <CheckBox fx:id="chkWin" text="%risk.config.win"/>
+                    <CheckBox fx:id="chkLoss" text="%risk.config.loss"/>
                 </HBox>
             </GridPane>
 
             <!-- Botones -->
             <HBox spacing="12" alignment="CENTER_RIGHT">
-                <Button text="Optimal Contracts" onAction="#onCalculate"/>
-                <Button text="Close" onAction="#onClose"/>
+                <Button text="%risk.config.optimalcontracts" onAction="#onCalculate"/>
+                <Button text="%risk.config.close" onAction="#onClose"/>
             </HBox>
         </VBox>
     </center>

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -1,0 +1,121 @@
+app.title=CW-DARMM - Market Manager
+button.language=Language
+lang.es=Spanish
+lang.en=English
+
+# Tabs
+tab.markets=Markets
+tab.results=Results
+tab.marketdb=Market DB
+
+# Market Manager
+market.manager.header=Markets
+market.manager.open=Open Market
+market.manager.account=Account
+market.manager.market=Market
+market.manager.marketdata=Market Data
+market.manager.accountsize=Account Size
+market.manager.riska=Risk A
+market.manager.riskb=Risk B
+market.manager.finalhouse=Final House
+market.manager.finallunch=Final Lunch
+market.manager.actions=Actions
+
+# Market DB
+market.db.title=BD_MARKET
+market.db.future=Future
+market.db.account=Account
+market.db.marketdata=Market Data
+market.db.name=Name
+market.db.symbol=Symbol
+market.db.multiplier=Multiplier
+market.db.ticksize=Tick Size
+market.db.tickvalue=Tick Value
+market.db.margin=Margin
+market.db.commission=Commission
+market.db.refresh=Refresh
+market.db.close=Close
+
+# Result View
+result.view.title=Optimization Results
+result.view.asset=Asset
+result.view.broker=Broker
+result.view.assetsymbol=Asset Symbol
+result.view.target=Target
+result.view.slsize=SL Size
+result.view.riskpercontract=Risk/Contract
+result.view.optimalcontract=Optimal Contract
+result.view.capitalused=Total Capital Used
+result.view.realrisk=Real Risk
+result.view.profit=Potential Profit
+result.view.loss=Potential Loss
+result.view.riskpct=Risk Percentage
+result.view.recalculate=Recalculate
+result.view.close=Close
+
+# Open Market
+open.market.title=MARKET
+open.market.account=Account:
+open.market.market=Market:
+open.market.marketdata=Market Data:
+open.market.accountsize=Account Size:
+open.market.riska=Risk % A:
+open.market.riskb=Risk % B:
+open.market.open=Open Market
+open.market.close=Close
+
+# Risk Config
+risk.config.title=RISK MANAGER
+risk.config.step1=Step 1 – Account:
+risk.config.step2=Step 2 – Market:
+risk.config.step3=Step 3 – Market Data:
+risk.config.accountsize=Account Size:
+risk.config.risktoreward=Risk to Reward:
+risk.config.slsize=SL Size (Ticks):
+risk.config.stoplosssize=Stop Loss Size:
+risk.config.house=HOUSE
+risk.config.lunch=LUNCH
+risk.config.win=WIN
+risk.config.loss=LOSS
+risk.config.optimalcontracts=Optimal Contracts
+risk.config.close=Close
+
+# Risk Dashboard
+risk.dashboard.titleprefix=Risk Manager:\u0020
+risk.dashboard.manage=Risk Manage
+risk.dashboard.trade=# Trade
+risk.dashboard.wl=W/L
+risk.dashboard.account=Account
+risk.dashboard.marketdata=Market Data
+risk.dashboard.accountsize=Account Size
+risk.dashboard.riska=Risk Kelly A
+risk.dashboard.riskb=Risk Kelly B
+risk.dashboard.export=Export CSV
+risk.dashboard.close=Close
+risk.dashboard.window=Risk Manager
+
+# Optimal Contracts
+optimal.contracts.slsize=SL Size (Ticks)
+optimal.contracts.ticker=FUTURES TICKER
+optimal.contracts.optimal=Optimal Contract
+optimal.contracts.target=Target (Ticks)
+optimal.contracts.window=Optimal Contracts
+
+# Alerts and messages
+alert.norisk=No risk session configured
+alert.xmlgenerated=XML generated in:
+alert.ahkgenerated=AHK generated in:
+alert.select.market=Select Account, Market and Market Data.
+alert.select.session=Select at least HOUSE or LUNCH.
+alert.select.result=Select at least WIN or LOSS.
+alert.check.values=Check numeric values.
+alert.validation=Validation
+alert.openmarket.missing=Must select Account, Market and Market Data.
+alert.openmarket.number=Account Size, Risk A and Risk B must be numbers greater than zero.
+alert.delete.market=Delete this market?
+alert.csv.exported=CSV exported in:
+alert.csv.error=Error exporting CSV:
+
+# Stage titles
+stage.openmarket=Open Market
+stage.editmarket=Edit Market

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -1,0 +1,121 @@
+app.title=CW-DARMM - Gestor de Mercados
+button.language=Idioma
+lang.es=Español
+lang.en=Inglés
+
+# Tabs
+tab.markets=Mercados
+tab.results=Resultados
+tab.marketdb=BD de Mercados
+
+# Market Manager
+market.manager.header=Mercados
+market.manager.open=Abrir Mercado
+market.manager.account=Cuenta
+market.manager.market=Mercado
+market.manager.marketdata=Datos de Mercado
+market.manager.accountsize=Tamaño de Cuenta
+market.manager.riska=Riesgo A
+market.manager.riskb=Riesgo B
+market.manager.finalhouse=Final Casa
+market.manager.finallunch=Final Almuerzo
+market.manager.actions=Acciones
+
+# Market DB
+market.db.title=BD_MARKET
+market.db.future=Futuro
+market.db.account=Cuenta
+market.db.marketdata=Datos de Mercado
+market.db.name=Nombre
+market.db.symbol=Símbolo
+market.db.multiplier=Multiplicador
+market.db.ticksize=Tamaño Tick
+market.db.tickvalue=Valor Tick
+market.db.margin=Margen
+market.db.commission=Comisión
+market.db.refresh=Refrescar
+market.db.close=Cerrar
+
+# Result View
+result.view.title=Resultados de Optimización
+result.view.asset=Activo
+result.view.broker=Broker
+result.view.assetsymbol=Símbolo Activo
+result.view.target=Objetivo
+result.view.slsize=Tamaño SL
+result.view.riskpercontract=Riesgo/Contrato
+result.view.optimalcontract=Contrato Óptimo
+result.view.capitalused=Capital Total Usado
+result.view.realrisk=Riesgo Real
+result.view.profit=Ganancia Potencial
+result.view.loss=Pérdida Potencial
+result.view.riskpct=Porcentaje de Riesgo
+result.view.recalculate=Recalcular
+result.view.close=Cerrar
+
+# Open Market
+open.market.title=MARKET
+open.market.account=Cuenta:
+open.market.market=Mercado:
+open.market.marketdata=Datos de Mercado:
+open.market.accountsize=Tamaño de Cuenta:
+open.market.riska=Riesgo % A:
+open.market.riskb=Riesgo % B:
+open.market.open=Abrir Mercado
+open.market.close=Cerrar
+
+# Risk Config
+risk.config.title=RISK MANAGER
+risk.config.step1=Paso 1 – Cuenta:
+risk.config.step2=Paso 2 – Mercado:
+risk.config.step3=Paso 3 – Datos de Mercado:
+risk.config.accountsize=Tamaño de Cuenta:
+risk.config.risktoreward=Riesgo a Recompensa:
+risk.config.slsize=Tamaño SL (Ticks):
+risk.config.stoplosssize=Tamaño Stop Loss:
+risk.config.house=CASA
+risk.config.lunch=ALMUERZO
+risk.config.win=GANAR
+risk.config.loss=PERDER
+risk.config.optimalcontracts=Contratos Óptimos
+risk.config.close=Cerrar
+
+# Risk Dashboard
+risk.dashboard.titleprefix=Gestor de Riesgo:\u0020
+risk.dashboard.manage=Gestionar Riesgo
+risk.dashboard.trade=# Trade
+risk.dashboard.wl=W/L
+risk.dashboard.account=Cuenta
+risk.dashboard.marketdata=Datos de Mercado
+risk.dashboard.accountsize=Tamaño de Cuenta
+risk.dashboard.riska=Riesgo Kelly A
+risk.dashboard.riskb=Riesgo Kelly B
+risk.dashboard.export=Exportar CSV
+risk.dashboard.close=Cerrar
+risk.dashboard.window=Gestor de Riesgo
+
+# Optimal Contracts
+optimal.contracts.slsize=Tamaño SL (Ticks)
+optimal.contracts.ticker=FUTURES TICKER
+optimal.contracts.optimal=Contrato Óptimo
+optimal.contracts.target=Objetivo (Ticks)
+optimal.contracts.window=Contratos Óptimos
+
+# Alerts and messages
+alert.norisk=No hay sesión de riesgo configurada
+alert.xmlgenerated=XML generado en:
+alert.ahkgenerated=AHK generado en:
+alert.select.market=Selecciona Account, Market y Market Data.
+alert.select.session=Selecciona al menos HOUSE o LUNCH.
+alert.select.result=Selecciona al menos WIN o LOSS.
+alert.check.values=Revisa los valores numéricos.
+alert.validation=Validación
+alert.openmarket.missing=Debe seleccionar Account, Market y Market Data.
+alert.openmarket.number=Account Size, Risk A y Risk B deben ser números mayores a cero.
+alert.delete.market=¿Eliminar este market?
+alert.csv.exported=CSV exportado en:
+alert.csv.error=Error al exportar CSV:
+
+# Stage titles
+stage.openmarket=Abrir Mercado
+stage.editmarket=Editar Market


### PR DESCRIPTION
## Summary
- load FXML views with locale-specific resource bundles
- add Spanish and English message properties and replace hardcoded UI text
- include language picker in main window to reload the interface

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689acaa77d18832db8adf5608fff749a