### PR TITLE
Fix language switch reload

### DIFF
--- a/src/main/java/com/cwdarmm/controller/MainWindowController.java
+++ b/src/main/java/com/cwdarmm/controller/MainWindowController.java
@@ -70,10 +70,12 @@ public class MainWindowController {
     }
 
     private void reload(Locale locale) throws IOException {
+        // Guardamos la escena **antes** de recargar el FXML, porque al cargarse
+        // de nuevo el controlador se reinicia y los nodos todavía no tienen escena.
+        Scene scene = btnLanguage.getScene();
         springFXMLLoader.setLocale(locale);
         FXMLLoader loader = springFXMLLoader.load("/fxml/MainWindow.fxml");
         Parent root = loader.getRoot();
-        Scene scene = btnLanguage.getScene();
         scene.setRoot(root);
         scene.getWindow().setTitle(loader.getResources().getString("app.title"));
     }


### PR DESCRIPTION
## Summary
- Ensure language switch keeps reference to existing scene before reloading FXML to avoid NullPointerException

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM: could not transfer org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_689ad20a745c832d8a50bd961d45cf2b