### PR TITLE
Fix optimal row highlighting to match Excel

### DIFF
--- a/src/main/java/com/cwdarmm/service/OptimizationService.java
+++ b/src/main/java/com/cwdarmm/service/OptimizationService.java
@@ -134,13 +134,23 @@ public class OptimizationService {
             }
         }
 
-        // Marcar la fila con mayor Potential Profit (como resalte "óptimo")
+        // Marcar la fila con mayor Potential Profit (como resalte "óptimo").
+        // En Excel, si varias filas comparten el mismo Profit, se resalta
+        // únicamente la de mayor porcentaje de riesgo. Replicamos ese criterio
+        // para evitar resaltar múltiples filas cuando el profit redondeado es
+        // idéntico (caso de ES/MES enviado por el usuario).
         double maxProfit = results.stream()
                 .mapToDouble(r -> r.getPotentialProfit().get())
                 .max().orElse(Double.NaN);
 
+        double maxRiskPct = results.stream()
+                .filter(r -> Double.compare(r.getPotentialProfit().get(), maxProfit) == 0)
+                .mapToDouble(r -> r.getRiskPercentage().get())
+                .max().orElse(Double.NaN);
+
         results.forEach(r -> r.getOptimalRow().set(
-                Double.compare(r.getPotentialProfit().get(), maxProfit) == 0));
+                Double.compare(r.getPotentialProfit().get(), maxProfit) == 0 &&
+                        Double.compare(r.getRiskPercentage().get(), maxRiskPct) == 0));
 
         return results;
     }

--- a/src/test/java/com/cwdarmm/service/ExcelComparisonTest.java
+++ b/src/test/java/com/cwdarmm/service/ExcelComparisonTest.java
@@ -58,6 +58,7 @@ public class ExcelComparisonTest {
 
         List<ResultRowDTO> rows = svc.calculate(req);
         assertEquals(4, rows.size());
+
         // first row correspond to ES riskPct 1.575
         ResultRowDTO row0 = rows.get(0);
         assertEquals("S&P 500", row0.getAsset().get());
@@ -73,5 +74,14 @@ public class ExcelComparisonTest {
         assertEquals(1, row2.getOptimalContract().get());
         assertEquals(1.99, row2.getRiskPerContract().get(), 0.01);
         assertEquals(1.575, row2.getRiskPercentage().get());
+
+        // Solo la fila con mayor Profit y mayor porcentaje de riesgo debe resaltarse
+        long highlighted = rows.stream().filter(r -> r.getOptimalRow().get()).count();
+        assertEquals(1, highlighted);
+        ResultRowDTO highlightedRow = rows.stream()
+                .filter(r -> r.getOptimalRow().get())
+                .findFirst().orElseThrow();
+        assertEquals("MES", highlightedRow.getSymbol().get());
+        assertEquals(1.675, highlightedRow.getRiskPercentage().get());
     }
 }


### PR DESCRIPTION
## Summary
- Highlight only the row with highest risk percentage when multiple share the same profit to mirror Excel behaviour
- Extend ExcelComparisonTest to verify only the expected row is flagged as optimal

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ad62f450c832dbd69b2089f91c1a7