### PR TITLE
feat: split risk dashboard tables on trade reset

### DIFF
--- a/src/main/java/com/cwdarmm/controller/MarketRiskDashboardController.java
+++ b/src/main/java/com/cwdarmm/controller/MarketRiskDashboardController.java
@@ -18,10 +18,12 @@ import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
 import javafx.scene.control.*;
+import javafx.scene.layout.VBox;
 import javafx.util.Callback;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
+import javafx.application.Platform;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -36,6 +38,7 @@ import java.util.ResourceBundle;
 public class MarketRiskDashboardController {
     @FXML
     private Label lblContext;
+    @FXML private VBox tablesContainer;
     @FXML private TableView<RiskResultDTO> tableResults;
     // columnas:
     @FXML private TableColumn<RiskResultDTO,Integer> colTrade;
@@ -53,9 +56,18 @@ public class MarketRiskDashboardController {
     private final RiskAnalysisService riskAnalysisService; // inyectado con Spring
     private MarketDTO context;
 
+    private int tradesCount = 0;
+    private TableView<RiskResultDTO> currentTable;
+
     public void setContext(MarketDTO context) {
         this.context = context;
-        lblContext.setText(context.getMarket().getDescription());
+        lblContext.setText(context.getAccount().getDescription());
+        Platform.runLater(() -> {
+            Stage stage = (Stage) lblContext.getScene().getWindow();
+            if (stage != null) {
+                stage.setTitle(context.getAccount().getDescription() + " – " + resources.getString("risk.dashboard.window"));
+            }
+        });
         // inicializar la tabla con el resultado inicial (trade 0):
         var initial = List.of(RiskResultDTO.builder()
                 .tradeNumber(0).wl("INITIAL")
@@ -65,7 +77,8 @@ public class MarketRiskDashboardController {
                 .riskKellyA(context.getRiskA())
                 .riskKellyB(context.getRiskB())
                 .build());
-        tableResults.setItems(FXCollections.observableArrayList(initial));
+        currentTable = tableResults;
+        currentTable.setItems(FXCollections.observableArrayList(initial));
     }
 
     @FXML
@@ -110,9 +123,11 @@ public class MarketRiskDashboardController {
         colRiskB       .setCellValueFactory(feat ->
                 new ReadOnlyObjectWrapper<>(feat.getValue().getRiskKellyB()));
 
+        tableResults.setOnMouseClicked(e -> currentTable = tableResults);
+
         btnExportCsv.setOnAction(evt -> {
             try {
-                var list = tableResults.getItems();
+                var list = currentTable.getItems();
                 Path file = Path.of(System.getProperty("user.home"), "risk-results.csv");
                 outputService.exportRiskResultsToCsv(list, file);
                 new Alert(Alert.AlertType.INFORMATION, resources.getString("alert.csv.exported") + "\n" + file)
@@ -122,6 +137,59 @@ public class MarketRiskDashboardController {
                         .showAndWait();
             }
         });
+    }
+
+    private TableView<RiskResultDTO> createTable() {
+        TableView<RiskResultDTO> tv = new TableView<>();
+
+        TableColumn<RiskResultDTO, Integer> tTrade = new TableColumn<>(colTrade.getText());
+        tTrade.setCellValueFactory(new PropertyValueFactory<>("tradeNumber"));
+
+        TableColumn<RiskResultDTO, String> tWl = new TableColumn<>(colWl.getText());
+        tWl.setCellValueFactory(new PropertyValueFactory<>("wl"));
+        tWl.setCellFactory(col -> new TableCell<>() {
+            @Override protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || item==null) { setText(null); setStyle(""); }
+                else {
+                    setText(item);
+                    if ("WIN".equalsIgnoreCase(item)) {
+                        setStyle("-fx-background-color:#92D050;");
+                    } else if ("LOSS".equalsIgnoreCase(item)) {
+                        setStyle("-fx-background-color:#FF0000; -fx-text-fill:white;");
+                    } else {
+                        setStyle("");
+                    }
+                }
+            }
+        });
+
+        TableColumn<RiskResultDTO, String> tAccount = new TableColumn<>(colAccount.getText());
+        tAccount.setCellValueFactory(feat -> {
+            var acc = feat.getValue().getAccount();
+            String txt = (acc != null ? acc.getDescription() : "");
+            return new ReadOnlyStringWrapper(txt);
+        });
+
+        TableColumn<RiskResultDTO, String> tMarketData = new TableColumn<>(colMarketData.getText());
+        tMarketData.setCellValueFactory(feat -> {
+            var fd = feat.getValue().getMarketData();
+            String txt = (fd != null ? fd.getDescription() : "");
+            return new ReadOnlyStringWrapper(txt);
+        });
+
+        TableColumn<RiskResultDTO, BigDecimal> tAccountSize = new TableColumn<>(colAccountSize.getText());
+        tAccountSize.setCellValueFactory(feat -> new ReadOnlyObjectWrapper<>(feat.getValue().getAccountSize()));
+
+        TableColumn<RiskResultDTO, Double> tRiskA = new TableColumn<>(colRiskA.getText());
+        tRiskA.setCellValueFactory(feat -> new ReadOnlyObjectWrapper<>(feat.getValue().getRiskKellyA()));
+
+        TableColumn<RiskResultDTO, Double> tRiskB = new TableColumn<>(colRiskB.getText());
+        tRiskB.setCellValueFactory(feat -> new ReadOnlyObjectWrapper<>(feat.getValue().getRiskKellyB()));
+
+        tv.getColumns().addAll(tTrade, tWl, tAccount, tMarketData, tAccountSize, tRiskA, tRiskB);
+        tv.setOnMouseClicked(e -> currentTable = tv);
+        return tv;
     }
 
     @FXML
@@ -136,20 +204,41 @@ public class MarketRiskDashboardController {
         formCtrl.setMarketContext(context);
         formCtrl.setOnCalculated(req -> {
             List<RiskResultDTO> rows = riskAnalysisService.calculate(req);
-            var items = tableResults.getItems();
 
             if (req.isFirstTrade()) {
-                // primer trade: limpiamos y mostramos sólo INITIAL
-                items.clear();
-                items.addAll(rows);
-            } else {
-                // trade posterior: añadimos sólo la fila WIN/LOSS
-                items.addAll(rows);
+                currentTable.getItems().clear();
+                currentTable.getItems().addAll(rows);
+                tradesCount = 0;
+                return;
+            }
+
+            for (RiskResultDTO row : rows) {
+                if (row.getTradeNumber() == 1) {
+                    tradesCount++;
+                }
+                currentTable.getItems().add(row);
+
+                boolean startNew = tradesCount > 2 || "WIN".equalsIgnoreCase(row.getWl());
+                if (startNew) {
+                    TableView<RiskResultDTO> newTable = createTable();
+                    tablesContainer.getChildren().add(newTable);
+                    currentTable = newTable;
+                    RiskResultDTO initial = RiskResultDTO.builder()
+                            .tradeNumber(0).wl("INITIAL")
+                            .account(row.getAccount())
+                            .marketData(row.getMarketData())
+                            .accountSize(row.getAccountSize())
+                            .riskKellyA(row.getRiskKellyA())
+                            .riskKellyB(row.getRiskKellyB())
+                            .build();
+                    currentTable.setItems(FXCollections.observableArrayList(initial));
+                    tradesCount = 0;
+                }
             }
         });
         dialog.initOwner(tableResults.getScene().getWindow());
         dialog.initModality(Modality.APPLICATION_MODAL);
-        dialog.setTitle(context.getMarket().getDescription() + " – " + resources.getString("risk.dashboard.window"));
+        dialog.setTitle(context.getAccount().getDescription() + " – " + resources.getString("risk.dashboard.window"));
         dialog.setScene(new Scene(loader.getRoot()));
         dialog.showAndWait();
     }

--- a/src/main/resources/fxml/MarketRiskDashboard.fxml
+++ b/src/main/resources/fxml/MarketRiskDashboard.fxml
@@ -7,6 +7,7 @@
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.geometry.Insets?>
+<?import javafx.scene.layout.VBox?>
 <BorderPane xmlns:fx="http://javafx.com/fxml"
             fx:controller="com.cwdarmm.controller.MarketRiskDashboardController">
     <!-- Top: Título y botón Risk Manage -->
@@ -18,19 +19,23 @@
             <Button text="%risk.dashboard.manage" onAction="#onRiskManage" />
         </ToolBar>
     </top>
-    <!-- Center: TableView de resultados -->
+    <!-- Center: contenedor para múltiples tablas de resultados -->
     <center>
-        <TableView fx:id="tableResults">
-            <columns>
-                <TableColumn fx:id="colTrade" text="%risk.dashboard.trade"/>
-                <TableColumn fx:id="colWl"       text="%risk.dashboard.wl"/>
-                <TableColumn fx:id="colAccount"  text="%risk.dashboard.account"/>
-                <TableColumn fx:id="colMarketData" text="%risk.dashboard.marketdata"/>
-                <TableColumn fx:id="colAccountSize" text="%risk.dashboard.accountsize"/>
-                <TableColumn fx:id="colRiskA"    text="%risk.dashboard.riska"/>
-                <TableColumn fx:id="colRiskB"    text="%risk.dashboard.riskb"/>
-            </columns>
-        </TableView>
+        <VBox fx:id="tablesContainer">
+            <children>
+                <TableView fx:id="tableResults">
+                    <columns>
+                        <TableColumn fx:id="colTrade" text="%risk.dashboard.trade"/>
+                        <TableColumn fx:id="colWl"       text="%risk.dashboard.wl"/>
+                        <TableColumn fx:id="colAccount"  text="%risk.dashboard.account"/>
+                        <TableColumn fx:id="colMarketData" text="%risk.dashboard.marketdata"/>
+                        <TableColumn fx:id="colAccountSize" text="%risk.dashboard.accountsize"/>
+                        <TableColumn fx:id="colRiskA"    text="%risk.dashboard.riska"/>
+                        <TableColumn fx:id="colRiskB"    text="%risk.dashboard.riskb"/>
+                    </columns>
+                </TableView>
+            </children>
+        </VBox>
     </center>
     <!-- Bottom: botón Close con padding correcto -->
     <bottom>


### PR DESCRIPTION
## Summary
- Wrap risk results table in a `VBox` container to support multiple tables
- Track `tradesCount` and `currentTable` in `MarketRiskDashboardController`
- Auto-create new risk tables when trade limit is exceeded or a WIN row triggers a reset; each table can be exported separately and shows account name in the header

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a539823230832d85fb2893f2978726