### PR TITLE
feat: accumulate Kelly risk across trades

### DIFF
--- a/src/main/java/com/cwdarmm/controller/MarketRiskDashboardController.java
+++ b/src/main/java/com/cwdarmm/controller/MarketRiskDashboardController.java
@@ -52,18 +52,26 @@ public class MarketRiskDashboardController {
     private final SpringFXMLLoader springFXMLLoader;
     private final RiskAnalysisService riskAnalysisService; // inyectado con Spring
     private MarketDTO context;
+    // Porcentajes de riesgo actualizados trade a trade. Se mantienen aquí para
+    // reproducir el comportamiento acumulativo del XLSM (Kelly compounding).
+    private double currentRiskA;
+    private double currentRiskB;
 
     public void setContext(MarketDTO context) {
         this.context = context;
         lblContext.setText(context.getMarket().getDescription());
+        // Valores iniciales del XLSM: los guardamos como punto de partida para
+        // ir aplicando el porcentaje sobre el acumulado de cada trade.
+        currentRiskA = context.getRiskA();
+        currentRiskB = context.getRiskB();
         // inicializar la tabla con el resultado inicial (trade 0):
         var initial = List.of(RiskResultDTO.builder()
                 .tradeNumber(0).wl("INITIAL")
                 .account(context.getAccount())
                 .marketData(context.getMarketData())
                 .accountSize(context.getAccountSize())
-                .riskKellyA(context.getRiskA())
-                .riskKellyB(context.getRiskB())
+                .riskKellyA(currentRiskA)
+                .riskKellyB(currentRiskB)
                 .build());
         tableResults.setItems(FXCollections.observableArrayList(initial));
     }
@@ -134,9 +142,29 @@ public class MarketRiskDashboardController {
         Stage dialog = new Stage();
         formCtrl.setDialogStage(dialog);
         formCtrl.setMarketContext(context);
+        // Pasamos este controlador para que el formulario pueda consultar el
+        // riesgo acumulado antes de lanzar un nuevo cálculo.
+        formCtrl.setRiskSource(this);
         formCtrl.setOnCalculated(req -> {
             List<RiskResultDTO> rows = riskAnalysisService.calculate(req);
             var items = tableResults.getItems();
+
+            if (!rows.isEmpty()) {
+                // La fila WIN/LOSS devuelve el nuevo porcentaje Kelly aplicado
+                // tras el trade; lo guardamos para el siguiente cálculo.
+                RiskResultDTO last = rows.get(rows.size() - 1);
+                if ("WIN".equalsIgnoreCase(last.getWl()) || "LOSS".equalsIgnoreCase(last.getWl())) {
+                    if (last.getRiskKellyA() != null) {
+                        currentRiskA = last.getRiskKellyA();
+                    }
+                    if (last.getRiskKellyB() != null) {
+                        currentRiskB = last.getRiskKellyB();
+                    }
+                    // Persistimos en el contexto para reutilizar al reabrir el diálogo
+                    context.setRiskA(currentRiskA);
+                    context.setRiskB(currentRiskB);
+                }
+            }
 
             if (req.isFirstTrade()) {
                 // primer trade: limpiamos y mostramos sólo INITIAL
@@ -157,5 +185,17 @@ public class MarketRiskDashboardController {
 
     @FXML private void onClose() {
         ((Stage)tableResults.getScene().getWindow()).close();
+    }
+
+    /**
+     * Expuestos para que RiskConfigController pueda consultar el porcentaje
+     * acumulado de riesgo y enviarlo al servicio, replicando la lógica del XLSM.
+     */
+    public double getCurrentRiskA() {
+        return currentRiskA;
+    }
+
+    public double getCurrentRiskB() {
+        return currentRiskB;
     }
 }

--- a/src/main/java/com/cwdarmm/controller/RiskConfigController.java
+++ b/src/main/java/com/cwdarmm/controller/RiskConfigController.java
@@ -17,6 +17,7 @@ import com.cwdarmm.service.ExportService;
 import com.cwdarmm.service.RiskAnalysisService;
 import com.cwdarmm.service.RiskContext;
 import com.cwdarmm.controller.BdMarketController;
+import com.cwdarmm.controller.MarketRiskDashboardController;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
@@ -52,6 +53,8 @@ public class RiskConfigController {
     private MarketDTO marketContext;
     private java.math.BigDecimal pctHouse;
     private java.math.BigDecimal pctLunch;
+    // Referencia al dashboard para consultar el riesgo acumulado.
+    private MarketRiskDashboardController riskSource;
 
     @FXML
     private ComboBox<CatAccount> cbRiskAccount;
@@ -127,6 +130,15 @@ public class RiskConfigController {
         this.pctLunch = java.math.BigDecimal.valueOf(context.getRiskB());
     }
 
+    /**
+     * Inyectamos el controlador del dashboard para poder recuperar
+     * los porcentajes actuales de riesgo (Kelly A/B) y así encadenar
+     * los cálculos de forma acumulativa como en el XLSM.
+     */
+    public void setRiskSource(MarketRiskDashboardController source) {
+        this.riskSource = source;
+    }
+
 
     /** Para compatibilidad con viejos callers que usaban Runnable */
     public void setOnCalculated(Runnable callback) {
@@ -174,7 +186,7 @@ public class RiskConfigController {
         //    configurado inicialmente cuando es el primer trade
         //    (risk_market.frm), por lo que replicamos ese comportamiento
         //    antes de continuar con los cálculos.
-        RiskInputDTO req = buildRequest()
+        RiskInputDTO req = buildRequest(first)
                 .toBuilder()
                 .firstTrade(first)
                 .build();
@@ -327,7 +339,15 @@ public class RiskConfigController {
     /**
      * Devuelve un RiskInputDTO construido con los valores actuales del formulario
      */
-    public RiskInputDTO buildRequest() {
+    public RiskInputDTO buildRequest(boolean firstTrade) {
+        // Para el primer trade usamos los porcentajes definidos en el contexto; en los
+        // siguientes trades tomamos los porcentajes actuales del dashboard (Kelly
+        // acumulado) para que el servicio siga compounding como en el XLSM.
+        java.math.BigDecimal riskA = firstTrade ? pctHouse :
+                (riskSource == null ? pctHouse : java.math.BigDecimal.valueOf(riskSource.getCurrentRiskA()));
+        java.math.BigDecimal riskB = firstTrade ? pctLunch :
+                (riskSource == null ? pctLunch : java.math.BigDecimal.valueOf(riskSource.getCurrentRiskB()));
+
         return RiskInputDTO.builder()
                 .account(cbRiskAccount.getValue())
                 .market(cbRiskMarket.getValue())
@@ -341,8 +361,8 @@ public class RiskConfigController {
                 .lunch(chkLunch.isSelected())
                 .win(chkWin.isSelected())
                 .loss(chkLoss.isSelected())
-                .riskPctA(pctHouse)
-                .riskPctB(pctLunch)
+                .riskPctA(riskA)
+                .riskPctB(riskB)
                 .build();
     }
 }


### PR DESCRIPTION
## Summary
- track current Kelly A/B risk percentages on dashboard to mirror XLSM compounding
- pass current risk into configuration dialog and update after each trade
- persist updated risk percentages in market context

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68a54d429c18832d8628cce7b10720c1