### PR TITLE
feat: risk engine compounding and optimal contracts

### DIFF
--- a/src/main/java/com/cwdarmm/controller/MarketRiskDashboardController.java
+++ b/src/main/java/com/cwdarmm/controller/MarketRiskDashboardController.java
@@ -7,10 +7,14 @@ package com.cwdarmm.controller;
 
 import com.cwdarmm.config.SpringFXMLLoader;
 import com.cwdarmm.model.dto.MarketDTO;
+import com.cwdarmm.model.dto.OptimalContractRow;
+import com.cwdarmm.model.dto.ResultRowDTO;
 import com.cwdarmm.model.dto.RiskInputDTO;
 import com.cwdarmm.model.dto.RiskResultDTO;
 import com.cwdarmm.service.OutputService;
 import com.cwdarmm.service.RiskAnalysisService;
+import com.cwdarmm.service.OptimizationService;
+import com.cwdarmm.controller.OptimalContractsController;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.collections.FXCollections;
@@ -29,6 +33,8 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.ResourceBundle;
 
 @Component
@@ -51,6 +57,8 @@ public class MarketRiskDashboardController {
     private final OutputService outputService;
     private final SpringFXMLLoader springFXMLLoader;
     private final RiskAnalysisService riskAnalysisService; // inyectado con Spring
+    private final OptimizationService optimizationService;
+    private final Map<String, Stage> popups = new HashMap<>();
     private MarketDTO context;
 
     public void setContext(MarketDTO context) {
@@ -139,12 +147,38 @@ public class MarketRiskDashboardController {
             var items = tableResults.getItems();
 
             if (req.isFirstTrade()) {
-                // primer trade: limpiamos y mostramos sólo INITIAL
                 items.clear();
                 items.addAll(rows);
             } else {
-                // trade posterior: añadimos sólo la fila WIN/LOSS
-                items.addAll(rows);
+                int lastTrade = items.isEmpty() ? 0 : items.get(items.size()-1).getTradeNumber();
+                BigDecimal prevAcc = items.isEmpty() ? context.getAccountSize() : items.get(items.size()-1).getAccountSize();
+                RiskResultDTO r = rows.get(0);
+                r.setTradeNumber(lastTrade + 1);
+
+                List<ResultRowDTO> resultRows = optimizationService.calculate(req);
+                if (!resultRows.isEmpty()) {
+                    ResultRowDTO or = resultRows.get(0);
+                    BigDecimal risk = BigDecimal.valueOf(or.getPotentialLoss().get());
+                    BigDecimal profit = BigDecimal.valueOf(or.getPotentialProfit().get());
+                    if ("WIN".equalsIgnoreCase(r.getWl())) {
+                        r.setAccountSize(prevAcc.subtract(risk).add(profit));
+                    } else if ("LOSS".equalsIgnoreCase(r.getWl())) {
+                        r.setAccountSize(prevAcc.subtract(risk));
+                    } else {
+                        r.setAccountSize(prevAcc);
+                    }
+                } else {
+                    r.setAccountSize(prevAcc);
+                }
+
+                items.add(r);
+            }
+        });
+        formCtrl.setOnOptimalContracts((req, rows) -> {
+            try {
+                showOptimalContracts(req, rows);
+            } catch (IOException e) {
+                e.printStackTrace();
             }
         });
         dialog.initOwner(tableResults.getScene().getWindow());
@@ -157,5 +191,30 @@ public class MarketRiskDashboardController {
 
     @FXML private void onClose() {
         ((Stage)tableResults.getScene().getWindow()).close();
+    }
+
+    private void showOptimalContracts(RiskInputDTO req, List<OptimalContractRow> rows) throws IOException {
+        String key = req.getAccount().getId() + "-" + req.getMarket().getId() + "-" + req.getStopLossSize();
+        Stage stage = popups.get(key);
+        if (stage != null) {
+            OptimalContractsController ctrl = (OptimalContractsController) stage.getUserData();
+            ctrl.setItems(rows);
+            stage.toFront();
+        } else {
+            FXMLLoader loader = springFXMLLoader.load("/fxml/OptimalContractsView.fxml");
+            OptimalContractsController ctrl = loader.getController();
+            ctrl.setCriteriaAccount(req.getAccount().getDescription());
+            ctrl.setMarket(req.getMarket());
+            ctrl.setItems(rows);
+            Stage popup = new Stage();
+            popup.initOwner(tableResults.getScene().getWindow());
+            popup.initModality(Modality.NONE);
+            popup.setTitle(req.getAccount().getDescription() + " – " + resources.getString("optimal.contracts.window"));
+            popup.setScene(new Scene(loader.getRoot()));
+            popup.setUserData(ctrl);
+            popup.setOnCloseRequest(e -> popups.remove(key));
+            popups.put(key, popup);
+            popup.show();
+        }
     }
 }

--- a/src/main/java/com/cwdarmm/controller/RiskConfigController.java
+++ b/src/main/java/com/cwdarmm/controller/RiskConfigController.java
@@ -19,13 +19,9 @@ import com.cwdarmm.service.RiskContext;
 import com.cwdarmm.controller.BdMarketController;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
-import javafx.fxml.FXMLLoader;
-import com.cwdarmm.config.SpringFXMLLoader;
-import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.util.StringConverter;
 import lombok.RequiredArgsConstructor;
@@ -44,11 +40,11 @@ public class RiskConfigController {
     private final RiskAnalysisService riskAnalysisService;
     private final ReferenceDataService referenceDataService;
     private final ExportService exportService;
-    private final SpringFXMLLoader springFXMLLoader;
     private final BdMarketController bdMarketController;
     private final RiskContext riskContext;
     private Stage dialogStage;
     private Consumer<RiskInputDTO> onCalculated;
+    private java.util.function.BiConsumer<RiskInputDTO, List<OptimalContractRow>> onOptimalContracts;
     private MarketDTO marketContext;
     private java.math.BigDecimal pctHouse;
     private java.math.BigDecimal pctLunch;
@@ -136,6 +132,10 @@ public class RiskConfigController {
     /** La nueva sobrecarga que infiere bien el tipo de req */
     public void setOnCalculated(Consumer<RiskInputDTO> callback) {
         this.onCalculated = callback;
+    }
+
+    public void setOnOptimalContracts(java.util.function.BiConsumer<RiskInputDTO, List<OptimalContractRow>> handler) {
+        this.onOptimalContracts = handler;
     }
 
     @FXML
@@ -231,28 +231,13 @@ public class RiskConfigController {
             onCalculated.accept(req);   // ahora le paso el req con riesgo actualizado
         }
 
-        // 8) Mostrar ventana de Optimal Contracts
+        // 8) Mostrar ventana de Optimal Contracts a través del handler externo
         List<OptimalContractRow> optimalRows = riskAnalysisService.generateOptimalContracts(req);
-        showOptimalContracts(optimalRows, req.getAccount().getDescription(), req.getMarket());
+        if (onOptimalContracts != null) {
+            onOptimalContracts.accept(req, optimalRows);
+        }
         bdMarketController.refreshTable();
         dialogStage.close();
-    }
-
-    private void showOptimalContracts(List<OptimalContractRow> rows, String criteriaAccount, CatMarket market) throws IOException {
-        FXMLLoader loader = springFXMLLoader.load("/fxml/OptimalContractsView.fxml");
-        OptimalContractsController ctrl = loader.getController();
-        ctrl.setCriteriaAccount(criteriaAccount);
-        ctrl.setMarket(market);
-        ctrl.setItems(rows);
-
-        Stage popup = new Stage();
-        if (dialogStage != null && dialogStage.getOwner() != null) {
-            popup.initOwner(dialogStage.getOwner());
-        }
-        popup.initModality(Modality.NONE);
-        popup.setTitle(criteriaAccount + " – " + resources.getString("optimal.contracts.window"));
-        popup.setScene(new Scene(loader.getRoot()));
-        popup.show();
     }
 
     @FXML

--- a/src/main/java/com/cwdarmm/service/OptimalContractService.java
+++ b/src/main/java/com/cwdarmm/service/OptimalContractService.java
@@ -1,0 +1,32 @@
+package com.cwdarmm.service;
+
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+/**
+ * Calcula el número óptimo de contratos según el tamaño de la cuenta,
+ * el porcentaje de riesgo actual y el valor por tick del mercado.
+ */
+@Service
+public class OptimalContractService {
+
+    /**
+     * @param account       tamaño de la cuenta en dólares
+     * @param currentKellyB porcentaje Kelly B actual (por ejemplo 1.5)
+     * @param slSizeTicks   tamaño del stop-loss en ticks
+     * @param tickValue     valor monetario de un tick
+     * @return número entero de contratos óptimos
+     */
+    public int calculateOptimalContracts(BigDecimal account,
+                                         double currentKellyB,
+                                         int slSizeTicks,
+                                         double tickValue) {
+        if (account == null) return 0;
+        double riskPct = currentKellyB / 100.0;
+        double denom = slSizeTicks * tickValue;
+        if (denom <= 0) return 0;
+        double numerator = account.doubleValue() * riskPct;
+        return (int) Math.floor(numerator / denom);
+    }
+}

--- a/src/main/java/com/cwdarmm/service/RiskEngine.java
+++ b/src/main/java/com/cwdarmm/service/RiskEngine.java
@@ -1,0 +1,47 @@
+package com.cwdarmm.service;
+
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * Motor sencillo para aplicar la lógica de compounding/drawdown
+ * sobre el porcentaje de riesgo Kelly B. Mantiene el valor
+ * actual en memoria y lo actualiza tras cada trade.
+ */
+@Service
+public class RiskEngine {
+    private final double baseRiskB;
+    private double current;
+
+    public RiskEngine() {
+        this(0);
+    }
+
+    public RiskEngine(double baseRiskB) {
+        this.baseRiskB = baseRiskB;
+        this.current = 0;
+    }
+
+    /**
+     * Calcula el porcentaje Kelly B a utilizar en el trade actual y
+     * actualiza el estado interno para el siguiente trade.
+     *
+     * @param isWin resultado del trade previo (true si fue WIN)
+     * @return porcentaje Kelly B para el trade actual
+     */
+    public double calculateKellyB(boolean isWin) {
+        double next = current == 0 ? baseRiskB : current;
+        double result = next;
+        next = next * (isWin ? 1.05 : 0.98);
+        current = round(next);
+        return round(result);
+    }
+
+    private double round(double value) {
+        return BigDecimal.valueOf(value)
+                .setScale(6, RoundingMode.HALF_UP)
+                .doubleValue();
+    }
+}

--- a/src/test/java/com/cwdarmm/service/OptimalContractServiceTest.java
+++ b/src/test/java/com/cwdarmm/service/OptimalContractServiceTest.java
@@ -1,0 +1,15 @@
+package com.cwdarmm.service;
+
+import org.junit.jupiter.api.Test;
+import java.math.BigDecimal;
+import static org.junit.jupiter.api.Assertions.*;
+
+class OptimalContractServiceTest {
+    private final OptimalContractService service = new OptimalContractService();
+
+    @Test
+    void calculatesOptimalContracts() {
+        int result = service.calculateOptimalContracts(new BigDecimal("20000"), 1.5, 10, 12.5);
+        assertEquals(2, result);
+    }
+}

--- a/src/test/java/com/cwdarmm/service/RiskEngineTest.java
+++ b/src/test/java/com/cwdarmm/service/RiskEngineTest.java
@@ -1,0 +1,18 @@
+package com.cwdarmm.service;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RiskEngineTest {
+
+    @Test
+    void kellyBSequence() {
+        RiskEngine engine = new RiskEngine(1.5);
+        boolean[] outcomes = {true, false, true, true}; // W, L, W, W
+        double[] expected = {1.5, 1.575, 1.5435, 1.620675};
+        for (int i = 0; i < outcomes.length; i++) {
+            double val = engine.calculateKellyB(outcomes[i]);
+            assertEquals(expected[i], val, 1e-6);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add stateful RiskEngine with Kelly B compounding
- compute optimal contracts from account risk percent
- reuse Optimal Contracts windows and keep trade/account running totals

## Testing
- `mvn -q -e -Dtest=RiskEngineTest,OptimalContractServiceTest test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a552e99f54832db2e2a467b87a0aa2