### PR TITLE
Add menu bar and about dialog

### DIFF
--- a/src/main/java/com/cwdarmm/controller/AboutDialogController.java
+++ b/src/main/java/com/cwdarmm/controller/AboutDialogController.java
@@ -1,0 +1,25 @@
+package com.cwdarmm.controller;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import org.springframework.stereotype.Component;
+
+/**
+ * Controller for the About dialog that displays application version information.
+ */
+@Component
+public class AboutDialogController {
+
+    @FXML
+    private Label lblVersion;
+
+    @FXML
+    public void initialize() {
+        String version = getClass().getPackage().getImplementationVersion();
+        if (version == null) {
+            version = "1.0.0";
+        }
+        lblVersion.setText("CW-DARMM version " + version);
+    }
+}
+

--- a/src/main/java/com/cwdarmm/controller/MainWindowController.java
+++ b/src/main/java/com/cwdarmm/controller/MainWindowController.java
@@ -6,13 +6,17 @@ package com.cwdarmm.controller;
  */
 
 import com.cwdarmm.config.SpringFXMLLoader;
+import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.control.MenuButton;
-import javafx.scene.control.TabPane;
+import javafx.scene.control.MenuBar;
 import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.stage.FileChooser;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -24,11 +28,11 @@ import java.util.Locale;
 public class MainWindowController {
 
     @FXML private TabPane tabPane;
-    @FXML private javafx.scene.control.Tab tabMarkets;
+    @FXML private Tab tabMarkets;
 
-    @FXML private javafx.scene.control.Tab tabResults;
-    @FXML private javafx.scene.control.Tab tabMarketDb;
-    @FXML private MenuButton btnLanguage;
+    @FXML private Tab tabResults;
+    @FXML private Tab tabMarketDb;
+    @FXML private MenuBar menuBar;
 
     private final BdMarketController bdMarketController;
     private final ResultViewController resultViewController;
@@ -73,11 +77,34 @@ public class MainWindowController {
     private void reload(Locale locale) throws IOException {
         // Guardamos la escena **antes** de recargar el FXML, porque al cargarse
         // de nuevo el controlador se reinicia y los nodos todavía no tienen escena.
-        Scene scene = btnLanguage.getScene();
+        Scene scene = menuBar.getScene();
         springFXMLLoader.setLocale(locale);
         FXMLLoader loader = springFXMLLoader.load("/fxml/MainWindow.fxml");
         Parent root = loader.getRoot();
         scene.setRoot(root);
       //  scene.getWindow().setTitle(loader.getResources().getString("app.title"));
+    }
+
+    @FXML
+    private void openFile() {
+        FileChooser fileChooser = new FileChooser();
+        fileChooser.showOpenDialog(menuBar.getScene().getWindow());
+    }
+
+    @FXML
+    private void exit() {
+        Platform.exit();
+    }
+
+    @FXML
+    private void showAbout() throws IOException {
+        FXMLLoader loader = springFXMLLoader.load("/fxml/AboutDialog.fxml");
+        Parent root = loader.getRoot();
+        Stage stage = new Stage();
+        stage.setScene(new Scene(root));
+        stage.setTitle(loader.getResources().getString("menu.about"));
+        stage.initModality(Modality.APPLICATION_MODAL);
+        stage.initOwner(menuBar.getScene().getWindow());
+        stage.showAndWait();
     }
 }

--- a/src/main/resources/fxml/AboutDialog.fxml
+++ b/src/main/resources/fxml/AboutDialog.fxml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns:fx="http://javafx.com/fxml"
+      fx:controller="com.cwdarmm.controller.AboutDialogController"
+      alignment="CENTER" spacing="10" prefWidth="300" prefHeight="100">
+    <children>
+        <Label fx:id="lblVersion"/>
+    </children>
+</VBox>

--- a/src/main/resources/fxml/MainWindow.fxml
+++ b/src/main/resources/fxml/MainWindow.fxml
@@ -1,25 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?import javafx.scene.control.MenuButton?>
+<?import javafx.scene.control.Menu?>
+<?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.control.TabPane?>
-<?import javafx.scene.control.ToolBar?>
 <?import javafx.scene.layout.BorderPane?>
-<?import javafx.scene.layout.Pane?>
-<?import javafx.scene.layout.HBox?>
 
 <BorderPane xmlns:fx="http://javafx.com/fxml"
             fx:controller="com.cwdarmm.controller.MainWindowController">
     <top>
-        <ToolBar>
-            <Pane fx:id="spacer" HBox.hgrow="ALWAYS"/>
-            <MenuButton fx:id="btnLanguage" text="%button.language">
-                <items>
-                    <MenuItem text="%lang.es" onAction="#switchToSpanish"/>
-                    <MenuItem text="%lang.en" onAction="#switchToEnglish"/>
-                </items>
-            </MenuButton>
-        </ToolBar>
+        <MenuBar fx:id="menuBar">
+            <menus>
+                <Menu text="%menu.file">
+                    <items>
+                        <MenuItem text="%menu.open" onAction="#openFile"/>
+                        <MenuItem text="%menu.exit" onAction="#exit"/>
+                    </items>
+                </Menu>
+                <Menu text="%menu.options">
+                    <items>
+                        <Menu text="%menu.language">
+                            <items>
+                                <MenuItem text="%lang.es" onAction="#switchToSpanish"/>
+                                <MenuItem text="%lang.en" onAction="#switchToEnglish"/>
+                            </items>
+                        </Menu>
+                    </items>
+                </Menu>
+                <Menu text="%menu.help">
+                    <items>
+                        <MenuItem text="%menu.about" onAction="#showAbout"/>
+                    </items>
+                </Menu>
+            </menus>
+        </MenuBar>
     </top>
     <center>
         <TabPane fx:id="tabPane">

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -3,6 +3,15 @@ button.language=Language
 lang.es=Spanish
 lang.en=English
 
+# Menu
+menu.file=File
+menu.open=Open...
+menu.exit=Exit
+menu.options=Options
+menu.language=Language
+menu.help=Help
+menu.about=About...
+
 # Tabs
 tab.markets=Markets
 tab.results=Results

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -3,6 +3,15 @@ button.language=Idioma
 lang.es=Español
 lang.en=Inglés
 
+# Menu
+menu.file=Archivo
+menu.open=Abrir...
+menu.exit=Salir
+menu.options=Opciones
+menu.language=Idioma
+menu.help=Ayuda
+menu.about=Acerca de...
+
 # Tabs
 tab.markets=Mercados
 tab.results=Resultados


### PR DESCRIPTION
## Summary
- Replace the toolbar with a menu bar including File, Options and Help menus
- Add menu actions for opening files, exiting, language switching and About dialog
- Introduce About dialog view and controller showing application version

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8337e288832d8a1c022ff081b940