### PR TITLE
Evitar cálculo duplicado de riesgo

### DIFF
--- a/src/main/java/com/cwdarmm/controller/MarketRiskDashboardController.java
+++ b/src/main/java/com/cwdarmm/controller/MarketRiskDashboardController.java
@@ -7,10 +7,8 @@ package com.cwdarmm.controller;
 
 import com.cwdarmm.config.SpringFXMLLoader;
 import com.cwdarmm.model.dto.MarketDTO;
-import com.cwdarmm.model.dto.RiskInputDTO;
 import com.cwdarmm.model.dto.RiskResultDTO;
 import com.cwdarmm.service.OutputService;
-import com.cwdarmm.service.RiskAnalysisService;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.collections.FXCollections;
@@ -50,7 +48,6 @@ public class MarketRiskDashboardController {
 
     private final OutputService outputService;
     private final SpringFXMLLoader springFXMLLoader;
-    private final RiskAnalysisService riskAnalysisService; // inyectado con Spring
     private MarketDTO context;
 
     public void setContext(MarketDTO context) {
@@ -134,8 +131,7 @@ public class MarketRiskDashboardController {
         Stage dialog = new Stage();
         formCtrl.setDialogStage(dialog);
         formCtrl.setMarketContext(context);
-        formCtrl.setOnCalculated(req -> {
-            List<RiskResultDTO> rows = riskAnalysisService.calculate(req);
+        formCtrl.setOnCalculated((req, rows) -> {
             var items = tableResults.getItems();
 
             if (req.isFirstTrade()) {

--- a/src/main/java/com/cwdarmm/controller/RiskConfigController.java
+++ b/src/main/java/com/cwdarmm/controller/RiskConfigController.java
@@ -36,6 +36,7 @@ import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.ResourceBundle;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 @Component
@@ -48,7 +49,7 @@ public class RiskConfigController {
     private final BdMarketController bdMarketController;
     private final RiskContext riskContext;
     private Stage dialogStage;
-    private Consumer<RiskInputDTO> onCalculated;
+    private BiConsumer<RiskInputDTO, List<RiskResultDTO>> onCalculated;
     private MarketDTO marketContext;
     private java.math.BigDecimal pctHouse;
     private java.math.BigDecimal pctLunch;
@@ -130,11 +131,16 @@ public class RiskConfigController {
 
     /** Para compatibilidad con viejos callers que usaban Runnable */
     public void setOnCalculated(Runnable callback) {
-        this.onCalculated = dto -> callback.run();
+        this.onCalculated = (req, rows) -> callback.run();
     }
 
-    /** La nueva sobrecarga que infiere bien el tipo de req */
+    /** La sobrecarga que acepta sólo el request */
     public void setOnCalculated(Consumer<RiskInputDTO> callback) {
+        this.onCalculated = (req, rows) -> callback.accept(req);
+    }
+
+    /** Nueva sobrecarga que entrega también las filas calculadas */
+    public void setOnCalculated(BiConsumer<RiskInputDTO, List<RiskResultDTO>> callback) {
         this.onCalculated = callback;
     }
 
@@ -228,7 +234,7 @@ public class RiskConfigController {
 
         // 7) Refrescar tabla (tu callback monta estas filas en la TableView)
         if (onCalculated != null) {
-            onCalculated.accept(req);   // ahora le paso el req con riesgo actualizado
+            onCalculated.accept(req, rows);   // ahora le paso el req con riesgo actualizado
         }
 
         // 8) Mostrar ventana de Optimal Contracts


### PR DESCRIPTION
## Summary
- Usa un `BiConsumer` en `RiskConfigController` para devolver las filas calculadas al callback.
- Actualiza `MarketRiskDashboardController` para reutilizar los resultados sin recalcular.

## Testing
- `mvn -q -e test` *(falló: Network is unreachable y no se pudieron resolver dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_68ae978561dc832dbad5ec37e8f0674d