### PR TITLE
Track sequential Kelly risk and accumulate optimal contract tables

### DIFF
--- a/src/main/java/com/cwdarmm/controller/OptimalContractsContainerController.java
+++ b/src/main/java/com/cwdarmm/controller/OptimalContractsContainerController.java
@@ -1,0 +1,35 @@
+package com.cwdarmm.controller;
+
+import com.cwdarmm.model.domain.CatMarket;
+import com.cwdarmm.model.dto.OptimalContractRow;
+import javafx.fxml.FXML;
+import javafx.scene.layout.HBox;
+import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Controlador de la ventana que acumula múltiples tablas de "Optimal Contracts".
+ * Cada cálculo añade una nueva tabla al contenedor horizontal sin eliminar las
+ * previas. Un botón de "Reset" permite limpiar manualmente el contenedor.
+ */
+@Component
+@RequiredArgsConstructor
+public class OptimalContractsContainerController {
+
+    @FXML private HBox tablesBox;
+
+    private final OptimalContractsPane paneFactory;
+
+    /** Agrega una nueva tabla al contenedor. */
+    public void addTable(List<OptimalContractRow> rows, String account, CatMarket market) {
+        tablesBox.getChildren().add(paneFactory.create(rows, account, market));
+    }
+
+    /** Elimina todas las tablas acumuladas. */
+    @FXML
+    private void onReset() {
+        tablesBox.getChildren().clear();
+    }
+}

--- a/src/main/java/com/cwdarmm/controller/OptimalContractsPane.java
+++ b/src/main/java/com/cwdarmm/controller/OptimalContractsPane.java
@@ -1,0 +1,38 @@
+package com.cwdarmm.controller;
+
+import com.cwdarmm.config.SpringFXMLLoader;
+import com.cwdarmm.model.domain.CatMarket;
+import com.cwdarmm.model.dto.OptimalContractRow;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Node;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Fábrica de paneles de contratos óptimos. Cada invocación carga el FXML de
+ * una tabla, asigna los datos y devuelve el nodo listo para insertarse en el
+ * contenedor padre.
+ */
+@Component
+@RequiredArgsConstructor
+public class OptimalContractsPane {
+
+    private final SpringFXMLLoader springFXMLLoader;
+
+    public Node create(List<OptimalContractRow> rows, String account, CatMarket market) {
+        try {
+            FXMLLoader loader = springFXMLLoader.load("/fxml/OptimalContractsView.fxml");
+            OptimalContractsController ctrl = loader.getController();
+            ctrl.setCriteriaAccount(account);
+            ctrl.setMarket(market);
+            ctrl.setItems(rows);
+            return loader.getRoot();
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to load OptimalContractsView.fxml", e);
+        }
+    }
+}

--- a/src/main/java/com/cwdarmm/controller/RiskConfigController.java
+++ b/src/main/java/com/cwdarmm/controller/RiskConfigController.java
@@ -17,6 +17,8 @@ import com.cwdarmm.service.ExportService;
 import com.cwdarmm.service.ReferenceDataService;
 import com.cwdarmm.service.RiskAnalysisService;
 import com.cwdarmm.service.RiskContext;
+import com.cwdarmm.service.RiskStateService;
+import com.cwdarmm.service.KellyType;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
@@ -46,12 +48,16 @@ public class RiskConfigController {
     private final SpringFXMLLoader springFXMLLoader;
     private final BdMarketController bdMarketController;
     private final RiskContext riskContext;
+    private final RiskStateService riskStateService;
     private Stage dialogStage;
 
     private BiConsumer<RiskInputDTO, List<RiskResultDTO>> onCalculated;
     private MarketDTO marketContext;
-    private java.math.BigDecimal pctHouse;
-    private java.math.BigDecimal pctLunch;
+    private BigDecimal pctHouse;
+    private BigDecimal pctLunch;
+
+    private Stage optimalStage;
+    private OptimalContractsContainerController optimalCtrl;
 
     @FXML
     private ComboBox<CatAccount> cbRiskAccount;
@@ -123,8 +129,13 @@ public class RiskConfigController {
         cbRiskAccount.setValue(context.getAccount());
         cbRiskMarket.setValue(context.getMarket());
         cbRiskMarketData.setValue(context.getMarketData());
-        this.pctHouse = java.math.BigDecimal.valueOf(context.getRiskA());
-        this.pctLunch = java.math.BigDecimal.valueOf(context.getRiskB());
+        Long accId = context.getAccount().getId();
+        Long mktId = context.getMarket().getId();
+        Long mdId  = context.getMarketData().getId();
+        this.pctHouse = BigDecimal.valueOf(
+                riskStateService.getLastRisk(accId, mktId, mdId, KellyType.A, context.getRiskA()));
+        this.pctLunch = BigDecimal.valueOf(
+                riskStateService.getLastRisk(accId, mktId, mdId, KellyType.B, context.getRiskB()));
     }
 
 
@@ -187,6 +198,17 @@ public class RiskConfigController {
             req = req.toBuilder()
                     .accountSize(BigDecimal.valueOf(req.getAccount().getInitialSize()))
                     .build();
+
+            // Reset del estado de riesgo semanal/inicial
+            Long accId = req.getAccount().getId();
+            Long mktId = req.getMarket().getId();
+            Long mdId = req.getMarketData().getId();
+            if (chkHouse.isSelected()) {
+                riskStateService.reset(accId, mktId, mdId, KellyType.A, marketContext.getRiskA());
+            }
+            if (chkLunch.isSelected()) {
+                riskStateService.reset(accId, mktId, mdId, KellyType.B, marketContext.getRiskB());
+            }
         }
 
         // 5) Llamamos al servicio que calcula el nuevo riesgo y registra el trade
@@ -195,11 +217,16 @@ public class RiskConfigController {
         // 5.a) Actualizamos los porcentajes de riesgo con los valores devueltos
         if (!rows.isEmpty()) {
             RiskResultDTO last = rows.get(rows.size() - 1);
+            Long accId = req.getAccount().getId();
+            Long mktId = req.getMarket().getId();
+            Long mdId = req.getMarketData().getId();
             if (last.getRiskKellyA() != null) {
-                this.pctHouse = java.math.BigDecimal.valueOf(last.getRiskKellyA());
+                this.pctHouse = BigDecimal.valueOf(last.getRiskKellyA());
+                riskStateService.save(accId, mktId, mdId, KellyType.A, last.getRiskKellyA());
             }
             if (last.getRiskKellyB() != null) {
-                this.pctLunch = java.math.BigDecimal.valueOf(last.getRiskKellyB());
+                this.pctLunch = BigDecimal.valueOf(last.getRiskKellyB());
+                riskStateService.save(accId, mktId, mdId, KellyType.B, last.getRiskKellyB());
             }
             // reconstruimos el request con los porcentajes ajustados
             req = req.toBuilder()
@@ -240,20 +267,19 @@ public class RiskConfigController {
     }
 
     private void showOptimalContracts(List<OptimalContractRow> rows, String criteriaAccount, CatMarket market) throws IOException {
-        FXMLLoader loader = springFXMLLoader.load("/fxml/OptimalContractsView.fxml");
-        OptimalContractsController ctrl = loader.getController();
-        ctrl.setCriteriaAccount(criteriaAccount);
-        ctrl.setMarket(market);
-        ctrl.setItems(rows);
-
-        Stage popup = new Stage();
-        if (dialogStage != null && dialogStage.getOwner() != null) {
-            popup.initOwner(dialogStage.getOwner());
+        if (optimalStage == null) {
+            FXMLLoader loader = springFXMLLoader.load("/fxml/OptimalContractsContainer.fxml");
+            optimalCtrl = loader.getController();
+            optimalStage = new Stage();
+            if (dialogStage != null && dialogStage.getOwner() != null) {
+                optimalStage.initOwner(dialogStage.getOwner());
+            }
+            optimalStage.initModality(Modality.NONE);
+            optimalStage.setTitle(resources.getString("optimal.contracts.window"));
+            optimalStage.setScene(new Scene(loader.getRoot()));
         }
-        popup.initModality(Modality.NONE);
-        popup.setTitle(criteriaAccount + " – " + resources.getString("optimal.contracts.window"));
-        popup.setScene(new Scene(loader.getRoot()));
-        popup.show();
+        optimalCtrl.addTable(rows, criteriaAccount, market);
+        optimalStage.show();
     }
 
     @FXML

--- a/src/main/java/com/cwdarmm/service/ExcelRounding.java
+++ b/src/main/java/com/cwdarmm/service/ExcelRounding.java
@@ -1,0 +1,25 @@
+package com.cwdarmm.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * Utilidades de redondeo que replican exactamente el comportamiento de Excel.
+ * <p>
+ *  - {@link #r3(double)} redondea a tres decimales con HALF_UP.
+ *  - {@link #r2(double)} redondea a dos decimales con HALF_UP.
+ * </p>
+ */
+public final class ExcelRounding {
+    private ExcelRounding() {}
+
+    /** Redondeo a dos decimales (monto en USD por contrato). */
+    public static double r2(double v) {
+        return new BigDecimal(v).setScale(2, RoundingMode.HALF_UP).doubleValue();
+    }
+
+    /** Redondeo a tres decimales (porcentaje de riesgo). */
+    public static double r3(double v) {
+        return new BigDecimal(v).setScale(3, RoundingMode.HALF_UP).doubleValue();
+    }
+}

--- a/src/main/java/com/cwdarmm/service/KellyType.java
+++ b/src/main/java/com/cwdarmm/service/KellyType.java
@@ -1,0 +1,9 @@
+package com.cwdarmm.service;
+
+/**
+ * Identificador del tipo de serie Kelly utilizada para el manejo de riesgo.
+ * Equivale a los botones "House" (A) y "Lunch" (B) del libro original.
+ */
+public enum KellyType {
+    A, B
+}

--- a/src/main/java/com/cwdarmm/service/OptimalContractsCalculator.java
+++ b/src/main/java/com/cwdarmm/service/OptimalContractsCalculator.java
@@ -1,0 +1,60 @@
+package com.cwdarmm.service;
+
+import com.cwdarmm.model.domain.BdMarket;
+import com.cwdarmm.model.dto.OptimalContractRow;
+import com.cwdarmm.repository.BdMarketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Calculadora de contratos óptimos independiente de la capa de presentación.
+ * Cada invocación genera una tabla nueva con los valores para un target
+ * específico, replicando las fórmulas del libro Excel.
+ */
+@Service
+@RequiredArgsConstructor
+public class OptimalContractsCalculator {
+
+    private final BdMarketRepository bdMarketRepository;
+
+    /**
+     * Genera las filas de contratos óptimos para el target indicado.
+     *
+     * @param accountId    cuenta seleccionada
+     * @param marketId     mercado
+     * @param marketDataId feed de mercado
+     * @param accountSize  saldo de la cuenta
+     * @param riskPct      porcentaje de riesgo aplicado
+     * @param slTicks      tamaño del stop loss en ticks
+     * @param targetTicks  objetivo en ticks
+     */
+    public List<OptimalContractRow> calculate(Long accountId,
+                                              Long marketId,
+                                              Long marketDataId,
+                                              double accountSize,
+                                              double riskPct,
+                                              int slTicks,
+                                              int targetTicks) {
+        List<BdMarket> rows = bdMarketRepository.findOneByMktAccMdata(marketId, accountId, marketDataId);
+        List<OptimalContractRow> result = new ArrayList<>();
+        if (rows.isEmpty()) {
+            return result;
+        }
+        for (BdMarket bd : rows) {
+            double riskUsd = accountSize * (riskPct / 100.0);
+            double riskPerContract = slTicks * bd.getTickValue() + bd.getCommission();
+            double contracts = riskPerContract <= 0 ? 0 : Math.floor(riskUsd / riskPerContract);
+            if (contracts < 1) {
+                result.add(new OptimalContractRow(slTicks, "The risk is too high", null, targetTicks));
+            } else {
+                BigDecimal opt = BigDecimal.valueOf(contracts);
+                result.add(new OptimalContractRow(slTicks, bd.getSymbol().getSymbol(), opt, targetTicks));
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
+++ b/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
@@ -78,8 +78,12 @@ public class RiskAnalysisService {
 
         // 3) Según el resultado del trade ajustamos los porcentajes de riesgo
         BigDecimal multiplier = in.isWin() ? new BigDecimal("1.05") : new BigDecimal("0.98");
-        BigDecimal newRiskA = in.isHouse() && in.getRiskPctA() != null ? in.getRiskPctA().multiply(multiplier) : null;
-        BigDecimal newRiskB = in.isLunch() && in.getRiskPctB() != null ? in.getRiskPctB().multiply(multiplier) : null;
+        BigDecimal newRiskA = in.isHouse() && in.getRiskPctA() != null
+                ? in.getRiskPctA().multiply(multiplier).setScale(3, BigDecimal.ROUND_HALF_UP)
+                : null;
+        BigDecimal newRiskB = in.isLunch() && in.getRiskPctB() != null
+                ? in.getRiskPctB().multiply(multiplier).setScale(3, BigDecimal.ROUND_HALF_UP)
+                : null;
 
         // 4) Registramos el trade actual, WIN o LOSS
         String wl = in.isWin() ? "WIN" : "LOSS";

--- a/src/main/java/com/cwdarmm/service/RiskStateService.java
+++ b/src/main/java/com/cwdarmm/service/RiskStateService.java
@@ -1,0 +1,113 @@
+package com.cwdarmm.service;
+
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Servicio encargado de mantener el estado del porcentaje de riesgo para cada
+ * combinación (account, market, marketData, kellyType). Replica el algoritmo
+ * anti-martingale del libro Excel/VBA.
+ */
+@Service
+public class RiskStateService {
+
+    public static final double FACTOR_WIN  = 1.05;
+    public static final double FACTOR_LOSS = 0.98;
+
+    private static final WeekFields WF = WeekFields.of(Locale.getDefault());
+
+    private final Map<StateKey, State> states = new ConcurrentHashMap<>();
+
+    /** Devuelve el último porcentaje de riesgo conocido para la clave indicada.
+     *  Si no existe o cambió de semana, devuelve e inicializa con el porcentaje
+     *  inicial proporcionado. */
+    public synchronized double getLastRisk(Long accountId,
+                                           Long marketId,
+                                           Long marketDataId,
+                                           KellyType type,
+                                           double initialRiskPct) {
+        StateKey key = new StateKey(accountId, marketId, marketDataId, type);
+        State state = states.get(key);
+        LocalDate today = LocalDate.now();
+        if (state == null || isNewWeek(state.lastDate, today)) {
+            double init = ExcelRounding.r3(initialRiskPct);
+            states.put(key, new State(init, today));
+            return init;
+        }
+        return state.lastRiskPct;
+    }
+
+    /**
+     * Aplica el resultado del trade (WIN/LOSS) y devuelve el nuevo porcentaje
+     * de riesgo, almacenándolo para futuras consultas.
+     */
+    public synchronized double applyTrade(Long accountId,
+                                          Long marketId,
+                                          Long marketDataId,
+                                          KellyType type,
+                                          double initialRiskPct,
+                                          boolean win) {
+        double prev = getLastRisk(accountId, marketId, marketDataId, type, initialRiskPct);
+        double factor = win ? FACTOR_WIN : FACTOR_LOSS;
+        double next = ExcelRounding.r3(prev * factor);
+        states.put(new StateKey(accountId, marketId, marketDataId, type),
+                new State(next, LocalDate.now()));
+        return next;
+    }
+
+    /** Guarda explícitamente un porcentaje de riesgo como último valor. */
+    public synchronized void save(Long accountId,
+                                  Long marketId,
+                                  Long marketDataId,
+                                  KellyType type,
+                                  double riskPct) {
+        states.put(new StateKey(accountId, marketId, marketDataId, type),
+                new State(ExcelRounding.r3(riskPct), LocalDate.now()));
+    }
+
+    /** Reinicia el estado para la clave indicada con el valor inicial. */
+    public synchronized void reset(Long accountId,
+                                   Long marketId,
+                                   Long marketDataId,
+                                   KellyType type,
+                                   double initialRiskPct) {
+        double init = ExcelRounding.r3(initialRiskPct);
+        states.put(new StateKey(accountId, marketId, marketDataId, type),
+                new State(init, LocalDate.now()));
+    }
+
+    private boolean isNewWeek(LocalDate prev, LocalDate now) {
+        if (prev == null) return true;
+        int w1 = prev.get(WF.weekOfWeekBasedYear());
+        int w2 = now.get(WF.weekOfWeekBasedYear());
+        int y1 = prev.get(WF.weekBasedYear());
+        int y2 = now.get(WF.weekBasedYear());
+        return w1 != w2 || y1 != y2;
+    }
+
+    private record State(double lastRiskPct, LocalDate lastDate) {}
+
+    private record StateKey(Long accountId, Long marketId, Long marketDataId, KellyType type) {
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof StateKey)) return false;
+            StateKey other = (StateKey) o;
+            return Objects.equals(accountId, other.accountId)
+                    && Objects.equals(marketId, other.marketId)
+                    && Objects.equals(marketDataId, other.marketDataId)
+                    && type == other.type;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(accountId, marketId, marketDataId, type);
+        }
+    }
+}

--- a/src/main/resources/fxml/OptimalContractsContainer.fxml
+++ b/src/main/resources/fxml/OptimalContractsContainer.fxml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<BorderPane xmlns:fx="http://javafx.com/fxml" fx:controller="com.cwdarmm.controller.OptimalContractsContainerController">
+    <top>
+        <ToolBar>
+            <Button text="Reset" onAction="#onReset" />
+        </ToolBar>
+    </top>
+    <center>
+        <ScrollPane fitToHeight="true">
+            <content>
+                <HBox fx:id="tablesBox" spacing="10" />
+            </content>
+        </ScrollPane>
+    </center>
+</BorderPane>


### PR DESCRIPTION
## Summary
- Introduce `RiskStateService` with Excel-style rounding and anti-martingale factors to persist Kelly A/B risk by account/market/feed
- Add `OptimalContractsContainerController`/`OptimalContractsPane` and FXML to append each Optimal Contracts table horizontally with a reset button
- Integrate risk state updates and cumulative table display in `RiskConfigController` and round risk percentages in `RiskAnalysisService`

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5160151c8832dbeda60a65e2fcab3