### PR TITLE
Implement sequential risk tracking and cumulative optimal contracts

### DIFF
--- a/src/main/java/com/cwdarmm/controller/OptimalContractsController.java
+++ b/src/main/java/com/cwdarmm/controller/OptimalContractsController.java
@@ -2,103 +2,20 @@ package com.cwdarmm.controller;
 
 import com.cwdarmm.model.domain.CatMarket;
 import com.cwdarmm.model.dto.OptimalContractRow;
-import javafx.beans.property.ReadOnlyObjectWrapper;
-import javafx.beans.property.ReadOnlyStringWrapper;
-import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.control.TableCell;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableView;
-import javafx.util.Callback;
+import javafx.scene.layout.HBox;
 import org.springframework.stereotype.Component;
 
-import java.math.BigDecimal;
 import java.util.List;
 
 @Component
 public class OptimalContractsController {
 
-    @FXML private Label                         lblAccount;
-    @FXML private TableView<OptimalContractRow> tblOptimal;
-    @FXML private TableColumn<OptimalContractRow, Integer>    colSlSize;
-    @FXML private TableColumn<OptimalContractRow, String>     colTicker;
-    @FXML private TableColumn<OptimalContractRow, BigDecimal> colOptimal;
-    @FXML private TableColumn<OptimalContractRow, Integer>    colTarget;
+    @FXML private Label lblAccount;
+    @FXML private HBox boxTables;
 
     private CatMarket market;
-
-    @FXML
-    public void initialize() {
-        // CellValueFactories
-        colSlSize .setCellValueFactory(c -> new ReadOnlyObjectWrapper<>(c.getValue().getSlSize()));
-        colTicker .setCellValueFactory(c -> new ReadOnlyStringWrapper(    c.getValue().getFuturesTicker()));
-        colOptimal.setCellValueFactory(c -> new ReadOnlyObjectWrapper<>(c.getValue().getOptimalContract()));
-        colTarget .setCellValueFactory(c -> new ReadOnlyObjectWrapper<>(c.getValue().getTargetTicks()));
-
-        // Estilos fijos
-        colSlSize.setCellFactory(col -> new TableCell<OptimalContractRow, Integer>() {
-            @Override protected void updateItem(Integer item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
-                    setStyle("");
-                } else {
-                    setText(item.toString());
-                    setStyle("-fx-background-color:#FF0000; -fx-text-fill:white;");
-                }
-            }
-        });
-
-        colTarget.setCellFactory(col -> new TableCell<OptimalContractRow, Integer>() {
-            @Override protected void updateItem(Integer item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
-                    setStyle("");
-                } else {
-                    setText(item.toString());
-                    setStyle("-fx-background-color:#D3D3D3;");
-                }
-            }
-        });
-
-        // Usamos el factory genérico para ticker y optimal
-        colTicker .setCellFactory(colorFactory());
-        colOptimal.setCellFactory(colorFactory());
-    }
-
-    /**
-     * Método genérico que crea un Callback para colorear cualquier TableColumn<TipoFila,T>
-     * basándose en el ticker de la fila.
-     */
-    private <T> Callback<TableColumn<OptimalContractRow, T>, TableCell<OptimalContractRow, T>> colorFactory() {
-        return column -> new TableCell<OptimalContractRow, T>() {
-            @Override
-            protected void updateItem(T item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
-                    setStyle("");
-                } else {
-                    setText(item.toString());
-                    OptimalContractRow row = getTableView().getItems().get(getIndex());
-                    String c = colorForTicker(row.getFuturesTicker());
-                    if (c != null && !c.isBlank()) {
-                        setStyle("-fx-background-color:" + c + ";");
-                    } else {
-                        setStyle("");
-                    }
-                }
-            }
-        };
-    }
-
-    private String colorForTicker(String ticker) {
-        if (market == null || ticker == null) return null;
-        boolean isMicro = ticker.startsWith("M");
-        return isMicro ? market.getColor1() : market.getColor2();
-    }
 
     public void setMarket(CatMarket market) {
         this.market = market;
@@ -108,7 +25,12 @@ public class OptimalContractsController {
         lblAccount.setText(acc);
     }
 
-    public void setItems(List<OptimalContractRow> items) {
-        tblOptimal.setItems(FXCollections.observableArrayList(items));
+    public void addTable(List<OptimalContractRow> items, CatMarket market) {
+        boxTables.getChildren().add(OptimalContractsPane.build(items, market));
+    }
+
+    @FXML
+    private void onReset() {
+        boxTables.getChildren().clear();
     }
 }

--- a/src/main/java/com/cwdarmm/controller/OptimalContractsPane.java
+++ b/src/main/java/com/cwdarmm/controller/OptimalContractsPane.java
@@ -1,0 +1,91 @@
+package com.cwdarmm.controller;
+
+import com.cwdarmm.model.domain.CatMarket;
+import com.cwdarmm.model.dto.OptimalContractRow;
+import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.collections.FXCollections;
+import javafx.scene.control.*;
+import javafx.scene.layout.Region;
+import javafx.util.Callback;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Fábrica de TableView para mostrar tablas de Optimal Contracts.
+ * Cada invocación genera una tabla nueva lista para agregarse a un contenedor.
+ */
+public class OptimalContractsPane {
+
+    public static TableView<OptimalContractRow> build(List<OptimalContractRow> items, CatMarket market) {
+        TableView<OptimalContractRow> tbl = new TableView<>();
+        tbl.setItems(FXCollections.observableArrayList(items));
+
+        TableColumn<OptimalContractRow, Integer> colSlSize = new TableColumn<>("%optimal.contracts.slsize");
+        TableColumn<OptimalContractRow, String>  colTicker = new TableColumn<>("%optimal.contracts.ticker");
+        TableColumn<OptimalContractRow, BigDecimal> colOptimal = new TableColumn<>("%optimal.contracts.optimal");
+        TableColumn<OptimalContractRow, Integer> colTarget = new TableColumn<>("%optimal.contracts.target");
+
+        colSlSize.setCellValueFactory(c -> new ReadOnlyObjectWrapper<>(c.getValue().getSlSize()));
+        colTicker.setCellValueFactory(c -> new ReadOnlyStringWrapper(c.getValue().getFuturesTicker()));
+        colOptimal.setCellValueFactory(c -> new ReadOnlyObjectWrapper<>(c.getValue().getOptimalContract()));
+        colTarget.setCellValueFactory(c -> new ReadOnlyObjectWrapper<>(c.getValue().getTargetTicks()));
+
+        colSlSize.setCellFactory(col -> new TableCell<>() {
+            @Override protected void updateItem(Integer item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || item == null) {
+                    setText(null); setStyle("");
+                } else {
+                    setText(item.toString());
+                    setStyle("-fx-background-color:#FF0000; -fx-text-fill:white;");
+                }
+            }
+        });
+
+        colTarget.setCellFactory(col -> new TableCell<>() {
+            @Override protected void updateItem(Integer item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || item == null) {
+                    setText(null); setStyle("");
+                } else {
+                    setText(item.toString());
+                    setStyle("-fx-background-color:#D3D3D3;");
+                }
+            }
+        });
+
+        Callback<TableColumn<OptimalContractRow, ?>, TableCell<OptimalContractRow, ?>> colorFactory = column -> new TableCell<>() {
+            @Override protected void updateItem(Object item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || item == null) {
+                    setText(null); setStyle("");
+                } else {
+                    setText(item.toString());
+                    OptimalContractRow row = getTableView().getItems().get(getIndex());
+                    String c = colorForTicker(market, row.getFuturesTicker());
+                    if (c != null && !c.isBlank()) {
+                        setStyle("-fx-background-color:" + c + ";");
+                    } else {
+                        setStyle("");
+                    }
+                }
+            }
+        };
+
+        colTicker.setCellFactory(colorFactory);
+        colOptimal.setCellFactory(colorFactory);
+
+        tbl.getColumns().addAll(colSlSize, colTicker, colOptimal, colTarget);
+        tbl.setPrefHeight(Region.USE_COMPUTED_SIZE);
+        tbl.setPrefWidth(Region.USE_COMPUTED_SIZE);
+        return tbl;
+    }
+
+    private static String colorForTicker(CatMarket market, String ticker) {
+        if (market == null || ticker == null) return null;
+        boolean isMicro = ticker.startsWith("M");
+        return isMicro ? market.getColor1() : market.getColor2();
+    }
+}

--- a/src/main/java/com/cwdarmm/controller/RiskConfigController.java
+++ b/src/main/java/com/cwdarmm/controller/RiskConfigController.java
@@ -16,6 +16,7 @@ import com.cwdarmm.model.dto.RiskResultDTO;
 import com.cwdarmm.service.ExportService;
 import com.cwdarmm.service.ReferenceDataService;
 import com.cwdarmm.service.RiskAnalysisService;
+import com.cwdarmm.service.RiskStateService;
 import com.cwdarmm.service.RiskContext;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
@@ -46,7 +47,10 @@ public class RiskConfigController {
     private final SpringFXMLLoader springFXMLLoader;
     private final BdMarketController bdMarketController;
     private final RiskContext riskContext;
+    private final RiskStateService riskStateService;
     private Stage dialogStage;
+    private Stage optimalStage;
+    private OptimalContractsController optimalContractsController;
 
     private BiConsumer<RiskInputDTO, List<RiskResultDTO>> onCalculated;
     private MarketDTO marketContext;
@@ -112,6 +116,8 @@ public class RiskConfigController {
 
         // Carga imagen
         imgCoins.setImage(new Image(getClass().getResourceAsStream("/img/coins.png")));
+        chkWin.selectedProperty().addListener((obs, o, n) -> { if (n) chkLoss.setSelected(false); });
+        chkLoss.selectedProperty().addListener((obs, o, n) -> { if (n) chkWin.setSelected(false); });
     }
 
     public void setDialogStage(Stage stage) {
@@ -123,8 +129,8 @@ public class RiskConfigController {
         cbRiskAccount.setValue(context.getAccount());
         cbRiskMarket.setValue(context.getMarket());
         cbRiskMarketData.setValue(context.getMarketData());
-        this.pctHouse = java.math.BigDecimal.valueOf(context.getRiskA());
-        this.pctLunch = java.math.BigDecimal.valueOf(context.getRiskB());
+        this.pctHouse = RiskStateService.r3(riskStateService.getRisk(context.getAccount().getId(), context.getMarket().getId(), context.getMarketData().getId(), RiskStateService.KellyType.A, BigDecimal.valueOf(context.getRiskA())));
+        this.pctLunch = RiskStateService.r3(riskStateService.getRisk(context.getAccount().getId(), context.getMarket().getId(), context.getMarketData().getId(), RiskStateService.KellyType.B, BigDecimal.valueOf(context.getRiskB())));
     }
 
 
@@ -196,12 +202,15 @@ public class RiskConfigController {
         if (!rows.isEmpty()) {
             RiskResultDTO last = rows.get(rows.size() - 1);
             if (last.getRiskKellyA() != null) {
-                this.pctHouse = java.math.BigDecimal.valueOf(last.getRiskKellyA());
+                this.pctHouse = RiskStateService.r3(BigDecimal.valueOf(last.getRiskKellyA()));
+                riskStateService.updateRisk(req.getAccount().getId(), req.getMarket().getId(), req.getMarketData().getId(),
+                        RiskStateService.KellyType.A, pctHouse, BigDecimal.valueOf(marketContext.getRiskA()));
             }
             if (last.getRiskKellyB() != null) {
-                this.pctLunch = java.math.BigDecimal.valueOf(last.getRiskKellyB());
+                this.pctLunch = RiskStateService.r3(BigDecimal.valueOf(last.getRiskKellyB()));
+                riskStateService.updateRisk(req.getAccount().getId(), req.getMarket().getId(), req.getMarketData().getId(),
+                        RiskStateService.KellyType.B, pctLunch, BigDecimal.valueOf(marketContext.getRiskB()));
             }
-            // reconstruimos el request con los porcentajes ajustados
             req = req.toBuilder()
                     .riskPctA(pctHouse)
                     .riskPctB(pctLunch)
@@ -234,26 +243,28 @@ public class RiskConfigController {
 
         // 8) Mostrar ventana de Optimal Contracts
         List<OptimalContractRow> optimalRows = riskAnalysisService.generateOptimalContracts(req);
-        showOptimalContracts(optimalRows, req.getAccount().getDescription(), req.getMarket());
+        showOptimalContracts(optimalRows, req);
         bdMarketController.refreshTable();
         dialogStage.close();
     }
 
-    private void showOptimalContracts(List<OptimalContractRow> rows, String criteriaAccount, CatMarket market) throws IOException {
-        FXMLLoader loader = springFXMLLoader.load("/fxml/OptimalContractsView.fxml");
-        OptimalContractsController ctrl = loader.getController();
-        ctrl.setCriteriaAccount(criteriaAccount);
-        ctrl.setMarket(market);
-        ctrl.setItems(rows);
-
-        Stage popup = new Stage();
-        if (dialogStage != null && dialogStage.getOwner() != null) {
-            popup.initOwner(dialogStage.getOwner());
+    private void showOptimalContracts(List<OptimalContractRow> rows, RiskInputDTO req) throws IOException {
+        if (optimalStage == null) {
+            FXMLLoader loader = springFXMLLoader.load("/fxml/OptimalContractsView.fxml");
+            optimalContractsController = loader.getController();
+            optimalStage = new Stage();
+            if (dialogStage != null && dialogStage.getOwner() != null) {
+                optimalStage.initOwner(dialogStage.getOwner());
+            }
+            optimalStage.initModality(Modality.NONE);
+            optimalStage.setTitle(req.getAccount().getDescription() + " – " + resources.getString("optimal.contracts.window"));
+            optimalStage.setScene(new Scene(loader.getRoot()));
+            optimalStage.show();
         }
-        popup.initModality(Modality.NONE);
-        popup.setTitle(criteriaAccount + " – " + resources.getString("optimal.contracts.window"));
-        popup.setScene(new Scene(loader.getRoot()));
-        popup.show();
+        optimalContractsController.setMarket(req.getMarket());
+        optimalContractsController.setCriteriaAccount(req.getAccount().getDescription());
+        optimalContractsController.addTable(rows, req.getMarket());
+        optimalStage.toFront();
     }
 
     @FXML

--- a/src/main/java/com/cwdarmm/service/OptimalContractsCalculator.java
+++ b/src/main/java/com/cwdarmm/service/OptimalContractsCalculator.java
@@ -1,0 +1,139 @@
+package com.cwdarmm.service;
+
+import com.cwdarmm.model.domain.BdMarket;
+import com.cwdarmm.model.domain.CatContract;
+import com.cwdarmm.model.domain.CatMarket;
+import com.cwdarmm.model.domain.CatSymbol;
+import com.cwdarmm.model.dto.OptimalContractRow;
+import com.cwdarmm.model.dto.RiskInputDTO;
+import com.cwdarmm.repository.BdMarketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Servicio que calcula los contratos óptimos replicando las fórmulas
+ * del libro Excel. Extraído de RiskAnalysisService para reutilización.
+ */
+@Service
+@RequiredArgsConstructor
+public class OptimalContractsCalculator {
+
+    private final BdMarketRepository bdMarketRepo;
+
+    private static double r2(double v){
+        return new BigDecimal(v).setScale(2, RoundingMode.HALF_UP).doubleValue();
+    }
+    private static double r3(double v){
+        return new BigDecimal(v).setScale(3, RoundingMode.HALF_UP).doubleValue();
+    }
+
+    public List<OptimalContractRow> calculate(RiskInputDTO in){
+        List<BdMarket> rows = bdMarketRepo.findOneByMktAccMdata(
+                in.getMarket().getId(),
+                in.getAccount().getId(),
+                in.getMarketData().getId()
+        );
+        if(rows.isEmpty()){
+            throw new IllegalArgumentException("No BD_MARKET rows for selection");
+        }
+
+        BdMarket chosen;
+        if(in.isFirstTrade()){
+            chosen = rows.stream()
+                    .filter(r -> !r.getSymbol().getSymbol().startsWith("M"))
+                    .findFirst()
+                    .orElse(rows.get(0));
+        }else{
+            chosen = rows.stream()
+                    .filter(r -> r.getSymbol().getSymbol().startsWith("M"))
+                    .findFirst()
+                    .orElse(rows.stream()
+                            .min(Comparator.comparing(BdMarket::getTickValue))
+                            .orElse(rows.get(0)));
+        }
+
+        CatContract contract = chosen.getContract();
+        CatSymbol symbol = chosen.getSymbol();
+
+        BigDecimal riskA = in.getRiskPctA();
+        BigDecimal riskB = in.getRiskPctB();
+        int offset = offsetForMarket(in.getMarket());
+
+        return Stream.of(
+                in.isHouse() ? makeRowRange(in, chosen, riskA, contract, symbol, offset, in.isFirstTrade()) : null,
+                in.isLunch() ? makeRowRange(in, chosen, riskB, contract, symbol, offset, in.isFirstTrade()) : null
+        ).filter(Objects::nonNull).collect(Collectors.toList());
+    }
+
+    private int offsetForMarket(CatMarket market){
+        String name = market.getDescription();
+        return "NASDAQ".equalsIgnoreCase(name) ? 2 : 1;
+    }
+
+    private OptimalContractRow makeRowRange(RiskInputDTO in,
+                                            BdMarket bd,
+                                            BigDecimal riskPct,
+                                            CatContract contract,
+                                            CatSymbol symbol,
+                                            int offset,
+                                            boolean firstTrade){
+        BigDecimal appliedPct = riskPct == null ? BigDecimal.ZERO : riskPct;
+        BigDecimal currentRisk = in.getAccountSize()
+                .multiply(appliedPct)
+                .divide(BigDecimal.valueOf(100), 8, RoundingMode.HALF_UP);
+
+        BigDecimal tickValue = BigDecimal.valueOf(bd.getTickValue());
+        BigDecimal commission = BigDecimal.valueOf(bd.getCommission());
+
+        int start = in.getTicksSl1();
+        int end = start;
+
+        BigDecimal bestProfit = null;
+        BigDecimal bestContracts = null;
+        int bestSl = start;
+
+        for(int sl=start; sl<=end; sl++){
+            BigDecimal riskPerContract = tickValue
+                    .multiply(BigDecimal.valueOf(sl))
+                    .add(commission);
+            if(riskPerContract.compareTo(BigDecimal.ZERO) <= 0) continue;
+
+            BigDecimal optContracts = currentRisk.divide(riskPerContract,0,RoundingMode.DOWN);
+            if(firstTrade && optContracts.compareTo(BigDecimal.ONE) < 0){
+                optContracts = BigDecimal.valueOf(5);
+            }
+
+            BigDecimal decimalTarget = BigDecimal.valueOf(in.getRiskReward())
+                    .multiply(BigDecimal.valueOf(sl))
+                    .add(BigDecimal.valueOf(offset));
+
+            BigDecimal potentialProfit = optContracts
+                    .multiply(tickValue.multiply(decimalTarget))
+                    .subtract(commission.multiply(optContracts));
+
+            if(bestProfit == null || potentialProfit.compareTo(bestProfit) > 0){
+                bestProfit = potentialProfit;
+                bestContracts = optContracts;
+                bestSl = sl;
+            }
+        }
+
+        BigDecimal bestDecimalTarget = BigDecimal.valueOf(in.getRiskReward())
+                .multiply(BigDecimal.valueOf(bestSl))
+                .add(BigDecimal.valueOf(offset));
+        int targetTicks = Math.round(bestDecimalTarget.floatValue());
+        String futuresTicker = symbol.getSymbol();
+        if(bestContracts == null || bestContracts.compareTo(BigDecimal.ONE) < 0){
+            return new OptimalContractRow(start, "The risk is too high", null, targetTicks);
+        }
+        return new OptimalContractRow(bestSl, futuresTicker, bestContracts, targetTicks);
+    }
+}

--- a/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
+++ b/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
@@ -1,14 +1,8 @@
 package com.cwdarmm.service;
 
-import com.cwdarmm.model.domain.BdMarket;
-import com.cwdarmm.model.domain.CatContract;
-import com.cwdarmm.model.domain.CatSymbol;
-import com.cwdarmm.model.domain.CatMarket;
-import com.cwdarmm.model.dto.MarketDbRowDTO;
 import com.cwdarmm.model.dto.OptimalContractRow;
 import com.cwdarmm.model.dto.RiskInputDTO;
 import com.cwdarmm.model.dto.RiskResultDTO;
-import com.cwdarmm.repository.BdMarketRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.slf4j.Logger;
@@ -30,11 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -42,13 +32,8 @@ public class RiskAnalysisService {
 
     private static final Logger log = LoggerFactory.getLogger(RiskAnalysisService.class);
 
-    /**
-     * Valor por defecto si no se especifica el porcentaje de riesgo.
-     */
-    private static final BigDecimal DEFAULT_RISK_PCT = new BigDecimal("2.5");
 
-
-    private final BdMarketRepository bdMarketRepo;
+    private final OptimalContractsCalculator optimalContractsCalculator;
 
     /**
      * Ejecuta la simulación de trades y calcula métricas básicas.
@@ -79,7 +64,9 @@ public class RiskAnalysisService {
         // 3) Según el resultado del trade ajustamos los porcentajes de riesgo
         BigDecimal multiplier = in.isWin() ? new BigDecimal("1.05") : new BigDecimal("0.98");
         BigDecimal newRiskA = in.isHouse() && in.getRiskPctA() != null ? in.getRiskPctA().multiply(multiplier) : null;
+        if (newRiskA != null) newRiskA = newRiskA.setScale(3, java.math.RoundingMode.HALF_UP);
         BigDecimal newRiskB = in.isLunch() && in.getRiskPctB() != null ? in.getRiskPctB().multiply(multiplier) : null;
+        if (newRiskB != null) newRiskB = newRiskB.setScale(3, java.math.RoundingMode.HALF_UP);
 
         // 4) Registramos el trade actual, WIN o LOSS
         String wl = in.isWin() ? "WIN" : "LOSS";
@@ -97,176 +84,8 @@ public class RiskAnalysisService {
         return rows;
     }
 
-    /**
-     * Genera la tabla de Optimal Contracts para la ventana emergente,
-     * imitando las fórmulas del XLSM original.
-     */
+
     public List<OptimalContractRow> generateOptimalContracts(RiskInputDTO in) {
-        // 1) Traemos todas las filas de bd_markets para esta tupla (market, account, marketData)
-        List<BdMarket> rows = bdMarketRepo.findOneByMktAccMdata(
-                in.getMarket().getId(),
-                in.getAccount().getId(),
-                in.getMarketData().getId()
-        );
-        if (rows.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "No existe configuración BD_MARKET para " + " market:" +
-                            in.getMarket().getId() + " /  Account:" +
-                            in.getAccount().getId() + " /  marketData:" +
-                            in.getMarketData().getId()
-            );
-        }
-
-        log.debug("BD_MARKET rows found: {}", rows.size());
-
-        // 2) Selección del contrato “principal”
-        //    En el XLSM no pedías al usuario elegir “ES” vs “MES”,
-        //    así que usamos la fila cuyo multiplier == 1 (si existiera),
-        //    o, de lo contrario, la primera de la lista (equivalente al .get(0) previo).
-        // 1) Elegir primero el "micro" (MES, M2K, etc.) por tickValue más pequeño:
-        // 2) Selección: elegimos siempre el micro (symbol empieza por "M") o, si no, el de menor tickValue
-        // 2) Selección del contrato “principal”
-        BdMarket chosen;
-        if (in.isFirstTrade()) {
-            // Primer trade: elige siempre el “grande”, es decir, el que NO empieza con 'M'
-            chosen = rows.stream()
-                    .filter(r -> !r.getSymbol().getSymbol().startsWith("M"))
-                    .findFirst()
-                    .orElse(rows.get(0));
-            log.debug("First trade - selected contract: {}", chosen.getSymbol().getSymbol());
-        } else {
-            // Trades siguientes: usas tu lógica de micro / tickValue …
-            chosen = rows.stream()
-                    .filter(r -> r.getSymbol().getSymbol().startsWith("M"))
-                    .findFirst()
-                    .orElse(rows.stream()
-                            .min(Comparator.comparing(BdMarket::getTickValue))
-                            .orElse(rows.get(0)));
-            log.debug("Subsequent trade - selected contract: {}", chosen.getSymbol().getSymbol());
-        }
-
-        // Extraemos aquí los objetos contract y symbol para pasarlos a makeRow:
-        CatContract contract = chosen.getContract();
-        CatSymbol symbol = chosen.getSymbol();
-
-        // 3) Los porcentajes de riesgo llegan ya ajustados por compounding/drawdown
-        BigDecimal riskA = in.getRiskPctA();
-        BigDecimal riskB = in.getRiskPctB();
-
-
-        // 4) Determinamos el offset para el cálculo de targets según el mercado
-        int offset = offsetForMarket(in.getMarket());
-
-        // 5) Generamos una fila para cada "bote" (House/Lunch)
-        return Stream.of(
-                        in.isHouse() ? makeRowRange(in, chosen, riskA, contract, symbol, offset, in.isFirstTrade()) : null,
-                        in.isLunch() ? makeRowRange(in, chosen, riskB, contract, symbol, offset, in.isFirstTrade()) : null
-                )
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-    }
-
-    private int offsetForMarket(CatMarket market) {
-        String name = market.getDescription();
-        return "NASDAQ".equalsIgnoreCase(name) ? 2 : 1;
-    }
-
-    private OptimalContractRow makeRowRange(RiskInputDTO in,
-                                            BdMarket bd,
-                                            BigDecimal riskPct,
-                                            CatContract contract,
-                                            CatSymbol symbol,
-                                            int offset,
-                                            boolean firstTrade) {
-        // --- Mapeo directo de las celdas de Excel al código Java ---
-        // 1) Calcular el riesgo disponible para este trade
-        //    (sección "Risk per trade" en docs/GOOD ARTICLE.pdf)
-        BigDecimal appliedPct = riskPct == null ? DEFAULT_RISK_PCT : riskPct;
-        BigDecimal currentRisk = in.getAccountSize()
-                .multiply(appliedPct)
-                .divide(BigDecimal.valueOf(100), 8, BigDecimal.ROUND_HALF_UP);
-        log.debug("appliedPct={}, currentRisk={}", appliedPct, currentRisk);
-
-        BigDecimal tickValue = BigDecimal.valueOf(bd.getTickValue());
-        BigDecimal commission = BigDecimal.valueOf(bd.getCommission());
-        log.debug("tickValue={}, commission={}", tickValue, commission);
-
-        // 2) Establecemos el rango de SL ticks a evaluar
-        //    según lo introducido en la ventana de configuración
-// Sustitúyelo por:
-        int start = in.getTicksSl1();
-// El Excel evalúa un único tamaño de stop‑loss; no un rango
-        int end = start;
-
-        BigDecimal bestProfit = null;
-        BigDecimal bestContracts = null;
-        int bestSl = start;
-
-        // 3) Recorremos cada posible SL buscando la mejor relación
-        for (int sl = start; sl <= end; sl++) {
-            // 3.a) Riesgo por contrato = ticks SL * tickValue + comisión.
-            //     La versión VBA siempre suma la comisión al riesgo por
-            //     contrato, incluso en el primer trade.
-            BigDecimal riskPerContract = tickValue
-                    .multiply(BigDecimal.valueOf(sl))
-                    .add(commission);
-            log.debug("sl={}, riskPerContract={}", sl, riskPerContract);
-
-            if (riskPerContract.compareTo(BigDecimal.ZERO) <= 0) continue;
-
-            // 3.b) Número óptimo de contratos = floor(currentRisk / riskPerContract)
-            BigDecimal optContracts = currentRisk
-                    .divide(riskPerContract, 0, BigDecimal.ROUND_DOWN);
-            // En el primer trade el VBA permite operar 5 contratos como arranque
-            if (firstTrade && optContracts.compareTo(BigDecimal.ONE) < 0) {
-                optContracts = BigDecimal.valueOf(5);
-            }
-            log.debug("optContracts for sl {} = {}", sl, optContracts);
-
-            // 3.c) Ticks objetivo en formato decimal.
-            //     En el XLSM el valor se utiliza sin redondear para calcular
-            //     el beneficio potencial y luego se trunca al mostrarlo.
-            BigDecimal decimalTarget = BigDecimal.valueOf(in.getRiskReward())
-                    .multiply(BigDecimal.valueOf(sl))
-                    .add(BigDecimal.valueOf(offset));
-
-            // 3.d) Beneficio potencial restando comisiones
-            BigDecimal potentialProfit = optContracts
-                    .multiply(tickValue.multiply(decimalTarget))
-                    .subtract(commission.multiply(optContracts));
-            log.debug("potentialProfit for sl {} = {}", sl, potentialProfit);
-
-            // 3.e) Guardamos el mejor SL encontrado
-            if (bestProfit == null || potentialProfit.compareTo(bestProfit) > 0) {
-                bestProfit = potentialProfit;
-                bestContracts = optContracts;
-                bestSl = sl;
-                log.debug("New best found: sl={}, contracts={}, profit={}", sl, bestContracts, bestProfit);
-            }
-        }
-
-        // ——————————————————————————————
-        // REDONDEO del target **igual que en VBA** (no truncar)
-        BigDecimal bestDecimalTarget = BigDecimal.valueOf(in.getRiskReward())
-                .multiply(BigDecimal.valueOf(bestSl))
-                .add(BigDecimal.valueOf(offset));
-        int targetTicks = Math.round(bestDecimalTarget.floatValue());
-        String futuresTicker = symbol.getSymbol();
-        if (bestContracts == null || bestContracts.compareTo(BigDecimal.ONE) < 0) {
-            // riesgo excesivo → mensaje (mismo comportamiento que en el XLSM)
-            log.debug("Risk too high at first trade? {}", firstTrade);
-            return new OptimalContractRow(
-                    start,
-                    "The risk is too high",
-                    null,
-                    targetTicks
-            );
-        }
-
-        log.debug("Best SL={}, contracts={}, targetTicks={}", bestSl, bestContracts, targetTicks);
-        // 5) Devolvemos la fila que representa el escenario óptimo
-        return new OptimalContractRow(bestSl, futuresTicker, bestContracts, targetTicks);
+        return optimalContractsCalculator.calculate(in);
     }
 }
-
-

--- a/src/main/java/com/cwdarmm/service/RiskStateService.java
+++ b/src/main/java/com/cwdarmm/service/RiskStateService.java
@@ -1,0 +1,88 @@
+package com.cwdarmm.service;
+
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Mantiene el porcentaje de riesgo secuencial para cada combinación
+ * (account, market, feed, Kelly A/B). Replica el comportamiento de las
+ * macros del libro Excel aplicando los factores anti-martingale
+ * 1.05 (WIN) y 0.98 (LOSS).
+ */
+@Service
+public class RiskStateService {
+
+    public enum KellyType { A, B }
+
+    private static final BigDecimal FACTOR_WIN  = new BigDecimal("1.05");
+    private static final BigDecimal FACTOR_LOSS = new BigDecimal("0.98");
+
+    /** Utilidades de redondeo equivalentes a Excel */
+    private static double r2(double v){
+        return new BigDecimal(v).setScale(2, RoundingMode.HALF_UP).doubleValue();
+    }
+    public static double r3(double v){
+        return new BigDecimal(v).setScale(3, RoundingMode.HALF_UP).doubleValue();
+    }
+    public static BigDecimal r3(BigDecimal v){
+        return v.setScale(3, RoundingMode.HALF_UP);
+    }
+
+    private record Key(Long accountId, Long marketId, Long marketDataId, KellyType type){}
+    private static class State {
+        BigDecimal lastRisk;
+        LocalDate lastDate;
+        BigDecimal initialRisk;
+        State(BigDecimal lastRisk, LocalDate lastDate, BigDecimal initialRisk){
+            this.lastRisk = lastRisk;
+            this.lastDate = lastDate;
+            this.initialRisk = initialRisk;
+        }
+    }
+
+    private final Map<Key, State> states = new ConcurrentHashMap<>();
+
+    private boolean isNewWeek(LocalDate prev, LocalDate now){
+        if(prev == null) return false;
+        LocalDate lastMon = prev.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate nowMon  = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        return !lastMon.equals(nowMon);
+    }
+
+    /** Obtiene el riesgo previo para la clave. Si no existe o cambió la semana,
+     * se devuelve el riesgo inicial proporcionado. */
+    public BigDecimal getRisk(Long acc, Long mkt, Long feed, KellyType type, BigDecimal initial){
+        State st = states.get(new Key(acc,mkt,feed,type));
+        LocalDate today = LocalDate.now();
+        if(st == null || isNewWeek(st.lastDate, today)){
+            return initial;
+        }
+        return st.lastRisk;
+    }
+
+    /** Guarda el riesgo posterior a un trade para la clave. */
+    public void updateRisk(Long acc, Long mkt, Long feed, KellyType type, BigDecimal newRisk, BigDecimal initial){
+        states.put(new Key(acc,mkt,feed,type), new State(r3(newRisk), LocalDate.now(), initial));
+    }
+
+    /** Aplica el resultado de un trade y devuelve el nuevo riesgo. */
+    public BigDecimal applyTrade(Long acc, Long mkt, Long feed, KellyType type, boolean win, BigDecimal initial){
+        BigDecimal prev = getRisk(acc,mkt,feed,type, initial);
+        BigDecimal factor = win ? FACTOR_WIN : FACTOR_LOSS;
+        BigDecimal next = r3(prev.multiply(factor));
+        updateRisk(acc,mkt,feed,type,next,initial);
+        return next;
+    }
+
+    /** Limpia todos los estados almacenados. */
+    public void reset(){
+        states.clear();
+    }
+}

--- a/src/main/resources/fxml/OptimalContractsView.fxml
+++ b/src/main/resources/fxml/OptimalContractsView.fxml
@@ -5,23 +5,18 @@
 <BorderPane xmlns:fx="http://javafx.com/fxml"
             fx:controller="com.cwdarmm.controller.OptimalContractsController"
             prefWidth="500" prefHeight="300">
-
     <top>
         <ToolBar>
             <Label fx:id="lblAccount"
                    style="-fx-font-size:14px; -fx-font-weight:bold;"/>
+            <Button text="Reset" onAction="#onReset"/>
         </ToolBar>
     </top>
-
     <center>
-        <TableView fx:id="tblOptimal">
-            <columns>
-                <TableColumn fx:id="colSlSize"   text="%optimal.contracts.slsize" />
-                <TableColumn fx:id="colTicker"   text="%optimal.contracts.ticker" />
-                <TableColumn fx:id="colOptimal"  text="%optimal.contracts.optimal" />
-                <TableColumn fx:id="colTarget"   text="%optimal.contracts.target" />
-            </columns>
-        </TableView>
+        <ScrollPane fitToHeight="true" hbarPolicy="AS_NEEDED" vbarPolicy="NEVER">
+            <content>
+                <HBox fx:id="boxTables" spacing="10"/>
+            </content>
+        </ScrollPane>
     </center>
-
 </BorderPane>

--- a/src/test/java/com/cwdarmm/service/RiskAnalysisServiceCalcTest.java
+++ b/src/test/java/com/cwdarmm/service/RiskAnalysisServiceCalcTest.java
@@ -5,6 +5,7 @@ import com.cwdarmm.model.domain.CatMarketData;
 import com.cwdarmm.model.dto.RiskInputDTO;
 import com.cwdarmm.model.dto.RiskResultDTO;
 import com.cwdarmm.repository.BdMarketRepository;
+import com.cwdarmm.service.OptimalContractsCalculator;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -21,7 +22,7 @@ public class RiskAnalysisServiceCalcTest {
 
     // Creamos una instancia del servicio de riesgo usando un repositorio simulado (mock).
     // Esto es para poder probar sin depender de la base de datos.
-    private RiskAnalysisService service = new RiskAnalysisService(Mockito.mock(BdMarketRepository.class));
+    private RiskAnalysisService service = new RiskAnalysisService(new OptimalContractsCalculator(Mockito.mock(BdMarketRepository.class)));
 
     // Método auxiliar que construye un objeto base con datos de entrada mínimos.
     private RiskInputDTO baseInput() {

--- a/src/test/java/com/cwdarmm/service/RiskAnalysisServiceOptimalTest.java
+++ b/src/test/java/com/cwdarmm/service/RiskAnalysisServiceOptimalTest.java
@@ -4,6 +4,7 @@ import com.cwdarmm.model.domain.*;
 import com.cwdarmm.model.dto.RiskInputDTO;
 import com.cwdarmm.model.dto.OptimalContractRow;
 import com.cwdarmm.repository.BdMarketRepository;
+import com.cwdarmm.service.OptimalContractsCalculator;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -50,7 +51,7 @@ public class RiskAnalysisServiceOptimalTest {
                 .thenReturn(List.of(bd)); // ← Match por mercado, cuenta y config de datos
 
         // ✅ Creamos el servicio real con ese repositorio simulado
-        RiskAnalysisService service = new RiskAnalysisService(repo);
+        RiskAnalysisService service = new RiskAnalysisService(new OptimalContractsCalculator(repo));
 
         // 📥 Creamos el input del cálculo de riesgo
         RiskInputDTO req = RiskInputDTO.builder()
@@ -107,7 +108,7 @@ public class RiskAnalysisServiceOptimalTest {
         Mockito.when(repo.findOneByMktAccMdata(2L,1L,3L))
                 .thenReturn(List.of(es));
 
-        RiskAnalysisService service = new RiskAnalysisService(repo);
+        RiskAnalysisService service = new RiskAnalysisService(new OptimalContractsCalculator(repo));
 
         RiskInputDTO req = RiskInputDTO.builder()
                 .account(es.getAccount())
@@ -157,7 +158,7 @@ public class RiskAnalysisServiceOptimalTest {
         Mockito.when(repo.findOneByMktAccMdata(2L,1L,3L))
                 .thenReturn(List.of(es));
 
-        RiskAnalysisService service = new RiskAnalysisService(repo);
+        RiskAnalysisService service = new RiskAnalysisService(new OptimalContractsCalculator(repo));
 
         RiskInputDTO req = RiskInputDTO.builder()
                 .account(es.getAccount())


### PR DESCRIPTION
## Summary
- track Kelly A/B risk state per market/account with Excel-style rounding and anti-martingale factors
- add JavaFX pane that appends Optimal Contracts tables horizontally with reset option
- ensure Win/Loss selections are mutually exclusive and persist updated risk percentages

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5160151c8832dbeda60a65e2fcab3