### PR TITLE
Fix Kelly B risk persistence and rounding

### DIFF
--- a/src/main/java/com/cwdarmm/controller/MarketRiskDashboardController.java
+++ b/src/main/java/com/cwdarmm/controller/MarketRiskDashboardController.java
@@ -139,6 +139,13 @@ public class MarketRiskDashboardController {
             }
             // tanto si es primer trade como posterior, añadimos las filas calculadas
             items.addAll(rows);
+
+            if (req.getRiskPctA() != null) {
+                context.setRiskA(req.getRiskPctA().doubleValue());
+            }
+            if (req.getRiskPctB() != null) {
+                context.setRiskB(req.getRiskPctB().doubleValue());
+            }
         });
         dialog.initOwner(tableResults.getScene().getWindow());
         dialog.initModality(Modality.APPLICATION_MODAL);

--- a/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
+++ b/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -46,6 +47,11 @@ public class RiskAnalysisService {
      * Valor por defecto si no se especifica el porcentaje de riesgo.
      */
     private static final BigDecimal DEFAULT_RISK_PCT = new BigDecimal("2.5");
+
+    /** Multiplicadores compounding/contracción. */
+    private static final BigDecimal WIN_MULTIPLIER = new BigDecimal("1.05");
+    private static final BigDecimal LOSS_MULTIPLIER = new BigDecimal("0.98");
+    private static final int RISK_SCALE = 3;
 
 
     private final BdMarketRepository bdMarketRepo;
@@ -77,9 +83,13 @@ public class RiskAnalysisService {
         }
 
         // 3) Según el resultado del trade ajustamos los porcentajes de riesgo
-        BigDecimal multiplier = in.isWin() ? new BigDecimal("1.05") : new BigDecimal("0.98");
-        BigDecimal newRiskA = in.isHouse() && in.getRiskPctA() != null ? in.getRiskPctA().multiply(multiplier) : null;
-        BigDecimal newRiskB = in.isLunch() && in.getRiskPctB() != null ? in.getRiskPctB().multiply(multiplier) : null;
+        BigDecimal multiplier = in.isWin() ? WIN_MULTIPLIER : LOSS_MULTIPLIER;
+        BigDecimal newRiskA = in.isHouse() && in.getRiskPctA() != null
+                ? in.getRiskPctA().multiply(multiplier).setScale(RISK_SCALE, RoundingMode.HALF_UP)
+                : null;
+        BigDecimal newRiskB = in.isLunch() && in.getRiskPctB() != null
+                ? in.getRiskPctB().multiply(multiplier).setScale(RISK_SCALE, RoundingMode.HALF_UP)
+                : null;
 
         // 4) Registramos el trade actual, WIN o LOSS
         String wl = in.isWin() ? "WIN" : "LOSS";

--- a/src/test/java/com/cwdarmm/service/RiskAnalysisServiceCalcTest.java
+++ b/src/test/java/com/cwdarmm/service/RiskAnalysisServiceCalcTest.java
@@ -109,4 +109,40 @@ public class RiskAnalysisServiceCalcTest {
         assertEquals(3.0 * 0.98, r.getRiskKellyA(), 1e-9);
         assertEquals(2.0 * 0.98, r.getRiskKellyB(), 1e-9);
     }
+
+    /**
+     * Verifica la secuencia WIN → LOSS → WIN para Kelly B con redondeo a 3 decimales.
+     */
+    @Test
+    void kellyBSequenceUsesLastRisk() {
+        RiskInputDTO first = baseInput().toBuilder()
+                .firstTrade(false)
+                .lunch(true)
+                .win(true)
+                .riskPctB(new BigDecimal("1.500"))
+                .build();
+
+        double step1 = service.calculate(first).get(0).getRiskKellyB();
+        assertEquals(1.575, step1, 1e-9);
+
+        RiskInputDTO second = baseInput().toBuilder()
+                .firstTrade(false)
+                .lunch(true)
+                .win(false)
+                .riskPctB(BigDecimal.valueOf(step1))
+                .build();
+
+        double step2 = service.calculate(second).get(0).getRiskKellyB();
+        assertEquals(1.544, step2, 1e-9);
+
+        RiskInputDTO third = baseInput().toBuilder()
+                .firstTrade(false)
+                .lunch(true)
+                .win(true)
+                .riskPctB(BigDecimal.valueOf(step2))
+                .build();
+
+        double step3 = service.calculate(third).get(0).getRiskKellyB();
+        assertEquals(1.621, step3, 1e-9);
+    }
 }


### PR DESCRIPTION
## Summary
- keep Kelly multipliers as constants and round risk to 3 decimals
- update risk context so Kelly B uses last value across trades
- add unit test covering WIN→LOSS→WIN sequence for Kelly B

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b51afbba64832db9914f4a5ec57c53