### PR TITLE
Increase precision for Kelly risk calculations

### DIFF
--- a/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
+++ b/src/main/java/com/cwdarmm/service/RiskAnalysisService.java
@@ -51,7 +51,8 @@ public class RiskAnalysisService {
     /** Multiplicadores compounding/contracción. */
     private static final BigDecimal WIN_MULTIPLIER = new BigDecimal("1.05");
     private static final BigDecimal LOSS_MULTIPLIER = new BigDecimal("0.98");
-    private static final int RISK_SCALE = 3;
+    // Usamos más precisión para evitar redondeos prematuros en los porcentajes de riesgo.
+    private static final int RISK_SCALE = 6;
 
 
     private final BdMarketRepository bdMarketRepo;

--- a/src/test/java/com/cwdarmm/service/RiskAnalysisServiceCalcTest.java
+++ b/src/test/java/com/cwdarmm/service/RiskAnalysisServiceCalcTest.java
@@ -111,7 +111,8 @@ public class RiskAnalysisServiceCalcTest {
     }
 
     /**
-     * Verifica la secuencia WIN → LOSS → WIN para Kelly B con redondeo a 3 decimales.
+     * Verifica la secuencia WIN → LOSS → WIN para Kelly B manteniendo la precisión
+     * completa en cada paso (sin redondeo intermedio).
      */
     @Test
     void kellyBSequenceUsesLastRisk() {
@@ -133,7 +134,7 @@ public class RiskAnalysisServiceCalcTest {
                 .build();
 
         double step2 = service.calculate(second).get(0).getRiskKellyB();
-        assertEquals(1.544, step2, 1e-9);
+        assertEquals(1.5435, step2, 1e-9);
 
         RiskInputDTO third = baseInput().toBuilder()
                 .firstTrade(false)
@@ -143,6 +144,6 @@ public class RiskAnalysisServiceCalcTest {
                 .build();
 
         double step3 = service.calculate(third).get(0).getRiskKellyB();
-        assertEquals(1.621, step3, 1e-9);
+        assertEquals(1.620675, step3, 1e-9);
     }
 }


### PR DESCRIPTION
## Summary
- avoid premature rounding by computing risk percentages with six-decimal precision
- adjust Kelly B sequence test to match exact Excel results

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b51dd1731c832dbe1aa9bc8fa6511b