### PR TITLE
Display risk percentage with six decimal digits

### DIFF
--- a/src/main/java/com/cwdarmm/controller/ResultViewController.java
+++ b/src/main/java/com/cwdarmm/controller/ResultViewController.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 
 import java.util.ResourceBundle;
+import java.util.Locale;
 
 import java.util.List;
 
@@ -64,6 +65,13 @@ public class ResultViewController {
         colProfit             .setCellValueFactory(cd -> cd.getValue().getPotentialProfit().asObject());
         colLoss               .setCellValueFactory(cd -> cd.getValue().getPotentialLoss().asObject());
         colRiskPct            .setCellValueFactory(cd -> cd.getValue().getRiskPercentage().asObject());
+        colRiskPct.setCellFactory(col -> new TableCell<>() {
+            @Override
+            protected void updateItem(Double item, boolean empty) {
+                super.updateItem(item, empty);
+                setText(empty || item == null ? null : String.format(Locale.US, "%.6f", item));
+            }
+        });
 
         // Estilos de filas resaltadas
 

--- a/src/main/java/com/cwdarmm/service/OptimizationService.java
+++ b/src/main/java/com/cwdarmm/service/OptimizationService.java
@@ -24,6 +24,9 @@ public class OptimizationService {
     private static double r3(double v) {
         return new BigDecimal(v).setScale(3, BigDecimal.ROUND_HALF_UP).doubleValue();
     }
+    private static double r6(double v) {
+        return new BigDecimal(v).setScale(6, BigDecimal.ROUND_HALF_UP).doubleValue();
+    }
 
     private static int offsetFor(String marketDescription) {
         return "NASDAQ".equalsIgnoreCase(marketDescription) ? 2 : 1; // S&P500 → 1
@@ -130,7 +133,7 @@ public class OptimizationService {
                     row.getRealRisk().set(r3(realRiskPct));                   // 0.995
                     row.getPotentialProfit().set(r2(potentialProfit));        // 3.01
                     row.getPotentialLoss().set(r2(potentialLoss));            // 1.99
-                    row.getRiskPercentage().set(r3(riskPctApplied));          // 1.575 / 1.675
+                    row.getRiskPercentage().set(r6(riskPctApplied));          // 1.575000 / 1.675000
 
                     // Color por símbolo (micro vs grande)
                     String c1 = in.getMarket().getColor1();


### PR DESCRIPTION
## Summary
- add six-decimal rounding helper and apply it to risk percentage values
- format risk percentage column to always show six decimals in the results table

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.0 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b51fb8ab20832db063626adda8d7c2