### PR TITLE
Highlight optimal rows in results table

### DIFF
--- a/src/main/java/com/cwdarmm/controller/ResultViewController.java
+++ b/src/main/java/com/cwdarmm/controller/ResultViewController.java
@@ -77,10 +77,19 @@ public class ResultViewController {
 
         // 4) RowFactory para filas óptimas
         tblResults.setRowFactory(tv -> new TableRow<>() {
-            @Override protected void updateItem(ResultRowDTO item, boolean empty) {
+            @Override
+            protected void updateItem(ResultRowDTO item, boolean empty) {
                 super.updateItem(item, empty);
-                setStyle((empty || item == null) ? "" :
-                        (item.getOptimalRow().get() ? "-fx-background-color: yellow;" : ""));
+
+                if (empty || item == null) {
+                    getStyleClass().remove("optimal-row");
+                } else if (item.getOptimalRow().get()) {
+                    if (!getStyleClass().contains("optimal-row")) {
+                        getStyleClass().add("optimal-row");
+                    }
+                } else {
+                    getStyleClass().remove("optimal-row");
+                }
             }
         });
 

--- a/src/main/resources/styles/styles.css
+++ b/src/main/resources/styles/styles.css
@@ -14,3 +14,8 @@
 .text-field       { -fx-font-size: 11; }
 .button           { -fx-font-size: 11; -fx-font-weight: bold; }
 .chk .text        { -fx-fill: white; }
+
+/* Resaltado de filas óptimas en ResultView */
+.table-row-cell.optimal-row .table-cell {
+    -fx-background-color: yellow;
+}


### PR DESCRIPTION
## Summary
- Apply `optimal-row` style class to highlight optimal rows in Results table
- Add CSS rule to color optimal rows yellow, matching Excel highlighting

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5231c8c2c832db09494cf76eeeda0