### PR TITLE
Fix optimal row selection

### DIFF
--- a/src/main/java/com/cwdarmm/service/OptimizationService.java
+++ b/src/main/java/com/cwdarmm/service/OptimizationService.java
@@ -155,14 +155,14 @@ public class OptimizationService {
                 .mapToDouble(r -> r.getPotentialProfit().get())
                 .max().orElse(Double.NaN);
 
-        double maxRiskPct = results.stream()
+        double minRiskPct = results.stream()
                 .filter(r -> Double.compare(r.getPotentialProfit().get(), maxProfit) == 0)
                 .mapToDouble(r -> r.getRiskPercentage().get())
-                .max().orElse(Double.NaN);
+                .min().orElse(Double.NaN);
 
         results.forEach(r -> r.getOptimalRow().set(
                 Double.compare(r.getPotentialProfit().get(), maxProfit) == 0 &&
-                        Double.compare(r.getRiskPercentage().get(), maxRiskPct) == 0));
+                        Double.compare(r.getRiskPercentage().get(), minRiskPct) == 0));
 
         return results;
     }

--- a/src/test/java/com/cwdarmm/service/ExcelComparisonTest.java
+++ b/src/test/java/com/cwdarmm/service/ExcelComparisonTest.java
@@ -75,13 +75,13 @@ public class ExcelComparisonTest {
         assertEquals(1.99, row2.getRiskPerContract().get(), 0.01);
         assertEquals(1.575, row2.getRiskPercentage().get());
 
-        // Solo la fila con mayor Profit y mayor porcentaje de riesgo debe resaltarse
+        // Solo la fila con mayor Profit y menor porcentaje de riesgo debe resaltarse
         long highlighted = rows.stream().filter(r -> r.getOptimalRow().get()).count();
         assertEquals(1, highlighted);
         ResultRowDTO highlightedRow = rows.stream()
                 .filter(r -> r.getOptimalRow().get())
                 .findFirst().orElseThrow();
         assertEquals("MES", highlightedRow.getSymbol().get());
-        assertEquals(1.675, highlightedRow.getRiskPercentage().get());
+        assertEquals(1.575, highlightedRow.getRiskPercentage().get());
     }
 }


### PR DESCRIPTION
## Summary
- Highlight the Results row that has the highest profit with the lowest risk percentage
- Adjust unit test to verify new highlight rule

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5284cfce4832dbb70ed8cc68a51de