### PR TITLE
Fix optimal row highlight to match Excel behavior

### DIFF
--- a/src/main/java/com/cwdarmm/service/OptimizationService.java
+++ b/src/main/java/com/cwdarmm/service/OptimizationService.java
@@ -155,14 +155,17 @@ public class OptimizationService {
                 .mapToDouble(r -> r.getPotentialProfit().get())
                 .max().orElse(Double.NaN);
 
-        double minRiskPct = results.stream()
+        // Excel subraya la fila con MAYOR porcentaje de riesgo cuando el profit
+        // es idéntico. El código previo tomaba el mínimo, lo que producía un
+        // resaltado incorrecto en casos como ES/MES.
+        double maxRiskPct = results.stream()
                 .filter(r -> Double.compare(r.getPotentialProfit().get(), maxProfit) == 0)
                 .mapToDouble(r -> r.getRiskPercentage().get())
-                .min().orElse(Double.NaN);
+                .max().orElse(Double.NaN);
 
         results.forEach(r -> r.getOptimalRow().set(
                 Double.compare(r.getPotentialProfit().get(), maxProfit) == 0 &&
-                        Double.compare(r.getRiskPercentage().get(), minRiskPct) == 0));
+                        Double.compare(r.getRiskPercentage().get(), maxRiskPct) == 0));
 
         return results;
     }

--- a/src/test/java/com/cwdarmm/service/ExcelComparisonTest.java
+++ b/src/test/java/com/cwdarmm/service/ExcelComparisonTest.java
@@ -69,19 +69,79 @@ public class ExcelComparisonTest {
         assertEquals(0, row0.getOptimalContract().get());
         assertEquals(1.575, row0.getRiskPercentage().get());
 
-        ResultRowDTO row2 = rows.get(2); // MES riskPct 1.575
-        assertEquals("MES", row2.getSymbol().get());
-        assertEquals(1, row2.getOptimalContract().get());
-        assertEquals(1.99, row2.getRiskPerContract().get(), 0.01);
-        assertEquals(1.575, row2.getRiskPercentage().get());
+        ResultRowDTO row3 = rows.get(3); // MES riskPct 1.675
+        assertEquals("MES", row3.getSymbol().get());
+        assertEquals(1, row3.getOptimalContract().get());
+        assertEquals(1.99, row3.getRiskPerContract().get(), 0.01);
+        assertEquals(1.675, row3.getRiskPercentage().get());
 
-        // Solo la fila con mayor Profit y menor porcentaje de riesgo debe resaltarse
+        // Solo la fila con mayor Profit y mayor porcentaje de riesgo debe resaltarse
         long highlighted = rows.stream().filter(r -> r.getOptimalRow().get()).count();
         assertEquals(1, highlighted);
         ResultRowDTO highlightedRow = rows.stream()
                 .filter(r -> r.getOptimalRow().get())
                 .findFirst().orElseThrow();
         assertEquals("MES", highlightedRow.getSymbol().get());
-        assertEquals(1.575, highlightedRow.getRiskPercentage().get());
+        assertEquals(1.675, highlightedRow.getRiskPercentage().get());
+    }
+
+    @Test
+    void scenarioWithMoreContracts() {
+        BdMarket es = BdMarket.builder()
+                .id(1L)
+                .account(CatAccount.builder().id(1L).description("NEXGEN").build())
+                .market(CatMarket.builder().id(1L).description("S&P 500").color1("c1").color2("c2").build())
+                .marketData(CatMarketData.builder().id(1L).description("PROJECTX").build())
+                .contract(CatContract.builder().id(1L).description("E-mini S&P").build())
+                .symbol(CatSymbol.builder().id(1L).symbol("ES").build())
+                .tickValue(12.5)
+                .commission(2.08)
+                .build();
+        BdMarket mes = BdMarket.builder()
+                .id(2L)
+                .account(es.getAccount())
+                .market(es.getMarket())
+                .marketData(es.getMarketData())
+                .contract(CatContract.builder().id(2L).description("Micro E-mini S&P").build())
+                .symbol(CatSymbol.builder().id(2L).symbol("MES").build())
+                .tickValue(1.25)
+                .commission(0.74)
+                .build();
+
+        BdMarketRepository repo = Mockito.mock(BdMarketRepository.class);
+        Mockito.when(repo.findOneByMktAccMdata(1L,1L,1L)).thenReturn(List.of(es, mes));
+
+        OptimizationService svc = new OptimizationService(repo);
+
+        RiskInputDTO req = RiskInputDTO.builder()
+                .account(es.getAccount())
+                .market(es.getMarket())
+                .marketData(es.getMarketData())
+                .accountSize(new BigDecimal("240"))
+                .riskReward(2.0)
+                .ticksSl1(1)
+                .ticksSl2(1)
+                .house(false)
+                .lunch(true)
+                .win(true)
+                .firstTrade(false)
+                .riskPctB(new BigDecimal("1.5"))
+                .build();
+
+        List<ResultRowDTO> rows = svc.calculate(req);
+        assertEquals(4, rows.size());
+
+        ResultRowDTO row3 = rows.get(3); // MES riskPct 1.675 con 2 contratos
+        assertEquals(2, row3.getOptimalContract().get());
+        assertEquals(6.02, row3.getPotentialProfit().get(), 0.01);
+
+        long highlighted = rows.stream().filter(r -> r.getOptimalRow().get()).count();
+        assertEquals(1, highlighted);
+        ResultRowDTO highlightedRow = rows.stream()
+                .filter(r -> r.getOptimalRow().get())
+                .findFirst().orElseThrow();
+        assertEquals("MES", highlightedRow.getSymbol().get());
+        assertEquals(1.675, highlightedRow.getRiskPercentage().get());
+        assertEquals(2, highlightedRow.getOptimalContract().get());
     }
 }


### PR DESCRIPTION
## Summary
- select highlighted row by highest risk percentage when profits tie
- expand tests to cover highlight logic and multi-contract scenario

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b52ae61a20832d9435b55b0ae251e0