### PR TITLE
Align risk compounding and highlight with Excel macros

### DIFF
--- a/src/main/java/com/cwdarmm/service/OptimizationService.java
+++ b/src/main/java/com/cwdarmm/service/OptimizationService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -67,11 +68,11 @@ public class OptimizationService {
         // Aplicar compounding/drawdown al porcentaje de riesgo si no es el primer trade
         BigDecimal riskA = in.getRiskPctA();
         BigDecimal riskB = in.getRiskPctB();
-//        if (!in.isFirstTrade()) {
-//            BigDecimal multiplier = in.isWin() ? new BigDecimal("1.05") : new BigDecimal("0.98");
-//            riskA = riskA == null ? null : riskA.multiply(multiplier);
-//            riskB = riskB == null ? null : riskB.multiply(multiplier);
-//        }
+        if (!in.isFirstTrade()) {
+            BigDecimal multiplier = in.isWin() ? new BigDecimal("1.05") : new BigDecimal("0.98");
+            riskA = riskA == null ? null : riskA.multiply(multiplier).setScale(6, RoundingMode.HALF_UP);
+            riskB = riskB == null ? null : riskB.multiply(multiplier).setScale(6, RoundingMode.HALF_UP);
+        }
 
         // Lista de porcentajes base activos (Kelly A/B) + variación "x"
         List<BigDecimal> baseRiskPcts = new ArrayList<>();
@@ -146,23 +147,21 @@ public class OptimizationService {
             }
         }
 
-        // Marcar la fila con mayor Potential Profit (como resalte "óptimo").
-        // En Excel, si varias filas comparten el mismo Profit, se resalta
-        // únicamente la de mayor porcentaje de riesgo. Replicamos ese criterio
-        // para evitar resaltar múltiples filas cuando el profit redondeado es
-        // idéntico (caso de ES/MES enviado por el usuario).
+        // Marcar la primera fila con mayor Potential Profit (como resalte "óptimo"),
+        // replicando la macro de Excel que selecciona la primera ocurrencia.
         double maxProfit = results.stream()
                 .mapToDouble(r -> r.getPotentialProfit().get())
                 .max().orElse(Double.NaN);
 
-        double minRiskPct = results.stream()
-                .filter(r -> Double.compare(r.getPotentialProfit().get(), maxProfit) == 0)
-                .mapToDouble(r -> r.getRiskPercentage().get())
-                .min().orElse(Double.NaN);
-
-        results.forEach(r -> r.getOptimalRow().set(
-                Double.compare(r.getPotentialProfit().get(), maxProfit) == 0 &&
-                        Double.compare(r.getRiskPercentage().get(), minRiskPct) == 0));
+        boolean flagged = false;
+        for (ResultRowDTO r : results) {
+            if (!flagged && Double.compare(r.getPotentialProfit().get(), maxProfit) == 0) {
+                r.getOptimalRow().set(true);
+                flagged = true;
+            } else {
+                r.getOptimalRow().set(false);
+            }
+        }
 
         return results;
     }

--- a/src/test/java/com/cwdarmm/service/OptimizationServiceHighlightTest.java
+++ b/src/test/java/com/cwdarmm/service/OptimizationServiceHighlightTest.java
@@ -1,0 +1,124 @@
+package com.cwdarmm.service;
+
+import com.cwdarmm.model.domain.*;
+import com.cwdarmm.model.dto.ResultRowDTO;
+import com.cwdarmm.model.dto.RiskInputDTO;
+import com.cwdarmm.repository.BdMarketRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests that replicate several Excel scenarios provided by the user.
+ * They focus on the calculation of the risk percentage and the
+ * selection of the highlighted ("subrayado") row.
+ */
+public class OptimizationServiceHighlightTest {
+
+    private BdMarket buildEs() {
+        return BdMarket.builder()
+                .id(1L)
+                .account(CatAccount.builder().id(1L).description("NEXGEN").build())
+                .market(CatMarket.builder().id(1L).description("S&P 500").color1("c1").color2("c2").build())
+                .marketData(CatMarketData.builder().id(1L).description("PROJECTX").build())
+                .contract(CatContract.builder().id(1L).description("E-mini S&P").build())
+                .symbol(CatSymbol.builder().id(1L).symbol("ES").build())
+                .tickValue(12.5)
+                .commission(2.08)
+                .build();
+    }
+
+    private BdMarket buildMes(BdMarket es) {
+        return BdMarket.builder()
+                .id(2L)
+                .account(es.getAccount())
+                .market(es.getMarket())
+                .marketData(es.getMarketData())
+                .contract(CatContract.builder().id(2L).description("Micro E-mini S&P").build())
+                .symbol(CatSymbol.builder().id(2L).symbol("MES").build())
+                .tickValue(1.25)
+                .commission(0.74)
+                .build();
+    }
+
+    /**
+     * Example 1 from the user: both symbols yield zero contracts and the first
+     * row should be highlighted with a risk percentage of 1.620675.
+     */
+    @Test
+    void highlightFirstRowWhenNoContracts() {
+        BdMarket es = buildEs();
+        BdMarket mes = buildMes(es);
+
+        BdMarketRepository repo = Mockito.mock(BdMarketRepository.class);
+        Mockito.when(repo.findOneByMktAccMdata(1L,1L,1L)).thenReturn(List.of(es, mes));
+
+        OptimizationService svc = new OptimizationService(repo);
+
+        RiskInputDTO req = RiskInputDTO.builder()
+                .account(es.getAccount())
+                .market(es.getMarket())
+                .marketData(es.getMarketData())
+                .accountSize(new BigDecimal("100"))
+                .riskReward(2.0)
+                .ticksSl1(1)
+                .ticksSl2(1)
+                .house(false)
+                .lunch(true)
+                .win(true)
+                .firstTrade(false)
+                .riskPctB(new BigDecimal("1.5435"))
+                .build();
+
+        List<ResultRowDTO> rows = svc.calculate(req);
+        assertEquals(4, rows.size());
+
+        assertEquals(1.620675, rows.get(0).getRiskPercentage().get(), 0.000001);
+        assertEquals(1.720675, rows.get(1).getRiskPercentage().get(), 0.000001);
+
+        long highlighted = rows.stream().filter(r -> r.getOptimalRow().get()).count();
+        assertEquals(1, highlighted);
+        assertTrue(rows.get(0).getOptimalRow().get());
+    }
+
+    /**
+     * Example 3 from the user: account size 145, the row with risk 1.5435
+     * (symbol MES) must be highlighted.
+     */
+    @Test
+    void highlightMesWithLowerRisk() {
+        BdMarket es = buildEs();
+        BdMarket mes = buildMes(es);
+
+        BdMarketRepository repo = Mockito.mock(BdMarketRepository.class);
+        Mockito.when(repo.findOneByMktAccMdata(1L,1L,1L)).thenReturn(List.of(es, mes));
+
+        OptimizationService svc = new OptimizationService(repo);
+
+        RiskInputDTO req = RiskInputDTO.builder()
+                .account(es.getAccount())
+                .market(es.getMarket())
+                .marketData(es.getMarketData())
+                .accountSize(new BigDecimal("145"))
+                .riskReward(2.0)
+                .ticksSl1(1)
+                .ticksSl2(1)
+                .house(false)
+                .lunch(true)
+                .win(true)
+                .firstTrade(false)
+                .riskPctB(new BigDecimal("1.47"))
+                .build();
+
+        List<ResultRowDTO> rows = svc.calculate(req);
+        assertEquals(4, rows.size());
+
+        assertEquals(1.543500, rows.get(2).getRiskPercentage().get(), 0.000001);
+        assertTrue(rows.get(2).getOptimalRow().get());
+    }
+}
+


### PR DESCRIPTION
## Summary
- Apply 5%/2% compounding to risk percentages when calculating Results
- Match Excel highlight by selecting the first row with max profit
- Add regression tests covering Excel scenarios

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5338a9154832d82839dd012727e30