### PR TITLE
Ensure single highlighted result row

### DIFF
--- a/src/main/java/com/cwdarmm/service/OptimizationService.java
+++ b/src/main/java/com/cwdarmm/service/OptimizationService.java
@@ -160,9 +160,16 @@ public class OptimizationService {
                 .mapToDouble(r -> r.getRiskPercentage().get())
                 .min().orElse(Double.NaN);
 
-        results.forEach(r -> r.getOptimalRow().set(
-                Double.compare(r.getPotentialProfit().get(), maxProfit) == 0 &&
-                        Double.compare(r.getRiskPercentage().get(), minRiskPct) == 0));
+        boolean marked = false;
+        for (ResultRowDTO r : results) {
+            boolean optimal = !marked &&
+                    Double.compare(r.getPotentialProfit().get(), maxProfit) == 0 &&
+                    Double.compare(r.getRiskPercentage().get(), minRiskPct) == 0;
+            r.getOptimalRow().set(optimal);
+            if (optimal) {
+                marked = true;
+            }
+        }
 
         return results;
     }


### PR DESCRIPTION
## Summary
- prevent multiple rows from being highlighted in Results table by flagging only the first entry with max profit and lowest risk percentage

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5391a89e0832d8b88cdedaf14241d