### PR TITLE
Ensure results view highlights base risk and document Kelly updates

### DIFF
--- a/src/main/java/com/cwdarmm/service/OptimizationService.java
+++ b/src/main/java/com/cwdarmm/service/OptimizationService.java
@@ -146,23 +146,40 @@ public class OptimizationService {
             }
         }
 
-        // Marcar la fila con mayor Potential Profit (como resalte "óptimo").
-        // En Excel, si varias filas comparten el mismo Profit, se resalta
-        // únicamente la de mayor porcentaje de riesgo. Replicamos ese criterio
-        // para evitar resaltar múltiples filas cuando el profit redondeado es
-        // idéntico (caso de ES/MES enviado por el usuario).
-        double maxProfit = results.stream()
-                .mapToDouble(r -> r.getPotentialProfit().get())
-                .max().orElse(Double.NaN);
+        // Determinar qué fila subrayar en la vista Results.
+        //
+        // En el Excel original la fila resaltada corresponde al porcentaje de
+        // riesgo base (sin la variación "x"). Para replicarlo, priorizamos
+        // marcar aquella fila cuyo porcentaje de riesgo coincide exactamente
+        // con el porcentaje utilizado para el cálculo (riskA o riskB según el
+        // "bucket" activo). Si por alguna razón no hay coincidencia, usamos
+        // como fallback el antiguo criterio de mayor profit / menor riesgo.
+        BigDecimal highlightPct = null;
+        if (in.isLunch() && riskB != null) {
+            highlightPct = riskB; // Kelly B
+        } else if (in.isHouse() && riskA != null) {
+            highlightPct = riskA; // Kelly A
+        }
 
-        double minRiskPct = results.stream()
-                .filter(r -> Double.compare(r.getPotentialProfit().get(), maxProfit) == 0)
-                .mapToDouble(r -> r.getRiskPercentage().get())
-                .min().orElse(Double.NaN);
+        if (highlightPct != null) {
+            double ref = highlightPct.doubleValue();
+            results.forEach(r -> r.getOptimalRow().set(
+                    Double.compare(r.getRiskPercentage().get(), ref) == 0));
+        } else {
+            // Fallback: mayor profit y, en caso de empate, menor riesgo.
+            double maxProfit = results.stream()
+                    .mapToDouble(r -> r.getPotentialProfit().get())
+                    .max().orElse(Double.NaN);
 
-        results.forEach(r -> r.getOptimalRow().set(
-                Double.compare(r.getPotentialProfit().get(), maxProfit) == 0 &&
-                        Double.compare(r.getRiskPercentage().get(), minRiskPct) == 0));
+            double minRiskPct = results.stream()
+                    .filter(r -> Double.compare(r.getPotentialProfit().get(), maxProfit) == 0)
+                    .mapToDouble(r -> r.getRiskPercentage().get())
+                    .min().orElse(Double.NaN);
+
+            results.forEach(r -> r.getOptimalRow().set(
+                    Double.compare(r.getPotentialProfit().get(), maxProfit) == 0 &&
+                            Double.compare(r.getRiskPercentage().get(), minRiskPct) == 0));
+        }
 
         return results;
     }

--- a/src/test/java/com/cwdarmm/service/ResultHighlightTest.java
+++ b/src/test/java/com/cwdarmm/service/ResultHighlightTest.java
@@ -1,0 +1,86 @@
+package com.cwdarmm.service;
+
+import com.cwdarmm.model.domain.*;
+import com.cwdarmm.model.dto.ResultRowDTO;
+import com.cwdarmm.model.dto.RiskInputDTO;
+import com.cwdarmm.repository.BdMarketRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifica que la fila resaltada en la pestaña "Results" coincida con el
+ * porcentaje de riesgo base (sin la variación "x") para distintos saldos de
+ * cuenta y secuencias de resultados (WIN/LOSS).
+ */
+public class ResultHighlightTest {
+
+    private BdMarketRepository repoWithESAndMES() {
+        BdMarket es = BdMarket.builder()
+                .id(1L)
+                .account(CatAccount.builder().id(1L).description("NEXGEN").build())
+                .market(CatMarket.builder().id(1L).description("S&P 500").color1("c1").color2("c2").build())
+                .marketData(CatMarketData.builder().id(1L).description("PROJECTX").build())
+                .contract(CatContract.builder().id(1L).description("E-mini S&P").build())
+                .symbol(CatSymbol.builder().id(1L).symbol("ES").build())
+                .tickValue(12.5)
+                .commission(2.08)
+                .build();
+        BdMarket mes = BdMarket.builder()
+                .id(2L)
+                .account(es.getAccount())
+                .market(es.getMarket())
+                .marketData(es.getMarketData())
+                .contract(CatContract.builder().id(2L).description("Micro E-mini S&P").build())
+                .symbol(CatSymbol.builder().id(2L).symbol("MES").build())
+                .tickValue(1.25)
+                .commission(0.74)
+                .build();
+        BdMarketRepository repo = Mockito.mock(BdMarketRepository.class);
+        Mockito.when(repo.findOneByMktAccMdata(1L,1L,1L)).thenReturn(List.of(es, mes));
+        return repo;
+    }
+
+    private ResultRowDTO highlightedRow(List<ResultRowDTO> rows) {
+        return rows.stream().filter(r -> r.getOptimalRow().get()).findFirst().orElseThrow();
+    }
+
+    @Test
+    void highlightUsesBaseRiskForDifferentAccountSizes() {
+        OptimizationService svc = new OptimizationService(repoWithESAndMES());
+
+        // Escenario 1: saldo $200, primer WIN → riesgo B = 1.575%
+        RiskInputDTO req1 = RiskInputDTO.builder()
+                .account(CatAccount.builder().id(1L).description("NEXGEN").build())
+                .market(CatMarket.builder().id(1L).description("S&P 500").color1("c1").color2("c2").build())
+                .marketData(CatMarketData.builder().id(1L).description("PROJECTX").build())
+                .accountSize(new BigDecimal("200"))
+                .riskReward(2.0)
+                .ticksSl1(1)
+                .lunch(true)
+                .riskPctB(new BigDecimal("1.575"))
+                .build();
+        List<ResultRowDTO> rows1 = svc.calculate(req1);
+        assertEquals(1.575, highlightedRow(rows1).getRiskPercentage().get());
+
+        // Escenario 2: saldo $145 tras un LOSS → riesgo B = 1.5435%
+        RiskInputDTO req2 = req1.toBuilder()
+                .accountSize(new BigDecimal("145"))
+                .riskPctB(new BigDecimal("1.5435"))
+                .build();
+        List<ResultRowDTO> rows2 = svc.calculate(req2);
+        assertEquals(1.5435, highlightedRow(rows2).getRiskPercentage().get());
+
+        // Escenario 3: saldo $100 tras WIN → riesgo B = 1.620675%
+        RiskInputDTO req3 = req1.toBuilder()
+                .accountSize(new BigDecimal("100"))
+                .riskPctB(new BigDecimal("1.620675"))
+                .build();
+        List<ResultRowDTO> rows3 = svc.calculate(req3);
+        assertEquals(1.620675, highlightedRow(rows3).getRiskPercentage().get());
+    }
+}


### PR DESCRIPTION
## Summary
- Update results calculator to underline the row whose risk percentage matches the base Kelly value, falling back to profit-based selection when needed.
- Add regression tests covering multiple account sizes to verify the correct row is highlighted for Kelly B.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for org.springframework.boot:spring-boot-starter-parent:3.3.0)*


------
https://chatgpt.com/codex/tasks/task_e_68b53e35ff44832d8376e8fddab99cc6