### PR TITLE
Fix risk scenario highlighting after trades

### DIFF
--- a/src/main/java/com/cwdarmm/service/OptimizationService.java
+++ b/src/main/java/com/cwdarmm/service/OptimizationService.java
@@ -141,29 +141,16 @@ public class OptimizationService {
                     String chosen = (symbol != null && symbol.startsWith("M")) ? c1 : c2;
                     row.getRowColor().set(chosen);
 
+                    // Destacar el escenario de riesgo efectivo para el próximo trade.
+                    // Si el último trade fue ganador, se subraya la fila k=1 (Kelly B + x).
+                    // Tras una pérdida o en cualquier otro caso, se subraya la fila base k=0.
+                    boolean highlight = !in.isFirstTrade() && (in.isWin() ? k == 1 : k == 0);
+                    row.getOptimalRow().set(highlight);
+
                     results.add(row);
                 }
             }
         }
-
-        // Marcar la fila con mayor Potential Profit (como resalte "óptimo").
-        // En Excel, si varias filas comparten el mismo Profit, se resalta
-        // únicamente la de mayor porcentaje de riesgo. Replicamos ese criterio
-        // para evitar resaltar múltiples filas cuando el profit redondeado es
-        // idéntico (caso de ES/MES enviado por el usuario).
-        double maxProfit = results.stream()
-                .mapToDouble(r -> r.getPotentialProfit().get())
-                .max().orElse(Double.NaN);
-
-        double minRiskPct = results.stream()
-                .filter(r -> Double.compare(r.getPotentialProfit().get(), maxProfit) == 0)
-                .mapToDouble(r -> r.getRiskPercentage().get())
-                .min().orElse(Double.NaN);
-
-        results.forEach(r -> r.getOptimalRow().set(
-                Double.compare(r.getPotentialProfit().get(), maxProfit) == 0 &&
-                        Double.compare(r.getRiskPercentage().get(), minRiskPct) == 0));
-
         return results;
     }
 }

--- a/src/test/java/com/cwdarmm/service/ExcelComparisonTest.java
+++ b/src/test/java/com/cwdarmm/service/ExcelComparisonTest.java
@@ -75,13 +75,66 @@ public class ExcelComparisonTest {
         assertEquals(1.99, row2.getRiskPerContract().get(), 0.01);
         assertEquals(1.575, row2.getRiskPercentage().get());
 
-        // Solo la fila con mayor Profit y menor porcentaje de riesgo debe resaltarse
-        long highlighted = rows.stream().filter(r -> r.getOptimalRow().get()).count();
-        assertEquals(1, highlighted);
-        ResultRowDTO highlightedRow = rows.stream()
+        // Tras un WIN se debe subrayar el escenario Kelly B + 0.1 para cada instrumento
+        List<ResultRowDTO> highlightedRows = rows.stream()
                 .filter(r -> r.getOptimalRow().get())
-                .findFirst().orElseThrow();
-        assertEquals("MES", highlightedRow.getSymbol().get());
-        assertEquals(1.575, highlightedRow.getRiskPercentage().get());
+                .toList();
+        assertEquals(2, highlightedRows.size());
+        // Todas las filas resaltadas corresponden a la variante incrementada
+        highlightedRows.forEach(r -> assertEquals(1.675, r.getRiskPercentage().get(), 1e-9));
+    }
+
+    @Test
+    void lossHighlightsBaseScenario() {
+        BdMarket es = BdMarket.builder()
+                .id(1L)
+                .account(CatAccount.builder().id(1L).description("NEXGEN").build())
+                .market(CatMarket.builder().id(1L).description("S&P 500").color1("c1").color2("c2").build())
+                .marketData(CatMarketData.builder().id(1L).description("PROJECTX").build())
+                .contract(CatContract.builder().id(1L).description("E-mini S&P").build())
+                .symbol(CatSymbol.builder().id(1L).symbol("ES").build())
+                .tickValue(12.5)
+                .commission(2.08)
+                .build();
+        BdMarket mes = BdMarket.builder()
+                .id(2L)
+                .account(es.getAccount())
+                .market(es.getMarket())
+                .marketData(es.getMarketData())
+                .contract(CatContract.builder().id(2L).description("Micro E-mini S&P").build())
+                .symbol(CatSymbol.builder().id(2L).symbol("MES").build())
+                .tickValue(1.25)
+                .commission(0.74)
+                .build();
+
+        BdMarketRepository repo = Mockito.mock(BdMarketRepository.class);
+        Mockito.when(repo.findOneByMktAccMdata(1L,1L,1L)).thenReturn(List.of(es, mes));
+
+        OptimizationService svc = new OptimizationService(repo);
+
+        RiskInputDTO req = RiskInputDTO.builder()
+                .account(es.getAccount())
+                .market(es.getMarket())
+                .marketData(es.getMarketData())
+                .accountSize(new BigDecimal("145"))
+                .riskReward(2.0)
+                .ticksSl1(1)
+                .ticksSl2(1)
+                .house(false)
+                .lunch(true)
+                .win(false)
+                .firstTrade(false)
+                .riskPctB(new BigDecimal("1.5435"))
+                .build();
+
+        List<ResultRowDTO> rows = svc.calculate(req);
+        assertEquals(4, rows.size());
+
+        // Tras una LOSS se debe subrayar la variante base (sin +0.1)
+        List<ResultRowDTO> highlightedRows = rows.stream()
+                .filter(r -> r.getOptimalRow().get())
+                .toList();
+        assertEquals(2, highlightedRows.size());
+        highlightedRows.forEach(r -> assertEquals(1.5435, r.getRiskPercentage().get(), 1e-9));
     }
 }


### PR DESCRIPTION
## Summary
- highlight Kelly B + 0.1 after wins and base Kelly B after losses
- add regression tests for win and loss highlighting scenarios

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b5485da45c832dacbbf9be8790cdfb