### PR TITLE
Highlight next-trade risk scenario

### DIFF
--- a/src/main/java/com/cwdarmm/service/OptimizationService.java
+++ b/src/main/java/com/cwdarmm/service/OptimizationService.java
@@ -141,29 +141,17 @@ public class OptimizationService {
                     String chosen = (symbol != null && symbol.startsWith("M")) ? c1 : c2;
                     row.getRowColor().set(chosen);
 
+                    // Subrayado: tras un WIN se resalta la fila "base + x" (k=1),
+                    // tras un LOSS la fila base (k=0). No se resalta nada en el
+                    // primer trade (INITIAL).
+                    boolean highlight = !in.isFirstTrade() &&
+                            ((in.isWin() && k == 1) || (!in.isWin() && k == 0));
+                    row.getOptimalRow().set(highlight);
+
                     results.add(row);
                 }
             }
         }
-
-        // Marcar la fila con mayor Potential Profit (como resalte "óptimo").
-        // En Excel, si varias filas comparten el mismo Profit, se resalta
-        // únicamente la de mayor porcentaje de riesgo. Replicamos ese criterio
-        // para evitar resaltar múltiples filas cuando el profit redondeado es
-        // idéntico (caso de ES/MES enviado por el usuario).
-        double maxProfit = results.stream()
-                .mapToDouble(r -> r.getPotentialProfit().get())
-                .max().orElse(Double.NaN);
-
-        double minRiskPct = results.stream()
-                .filter(r -> Double.compare(r.getPotentialProfit().get(), maxProfit) == 0)
-                .mapToDouble(r -> r.getRiskPercentage().get())
-                .min().orElse(Double.NaN);
-
-        results.forEach(r -> r.getOptimalRow().set(
-                Double.compare(r.getPotentialProfit().get(), maxProfit) == 0 &&
-                        Double.compare(r.getRiskPercentage().get(), minRiskPct) == 0));
-
         return results;
     }
 }

--- a/src/test/java/com/cwdarmm/service/OptimizationServiceCalculateTest.java
+++ b/src/test/java/com/cwdarmm/service/OptimizationServiceCalculateTest.java
@@ -63,5 +63,55 @@ public class OptimizationServiceCalculateTest {
         assertEquals(3, row.getTarget().get()); // 1*1 + offset(2)
         assertEquals(5, row.getOptimalContract().get());
     }
+
+    /**
+     * The row highlighted for the next trade depends on the result of the
+     * previous trade. After a WIN the "base + x" scenario must be highlighted;
+     * after a LOSS the base scenario is highlighted.
+     */
+    @Test
+    void highlightRowMatchesTradeResult() {
+        BdMarket bd = BdMarket.builder()
+                .id(2L)
+                .account(CatAccount.builder().id(1L).description("ACC").build())
+                .market(CatMarket.builder().id(1L).description("S&P500").build())
+                .marketData(CatMarketData.builder().id(1L).description("DATA").build())
+                .contract(CatContract.builder().id(1L).description("ES").build())
+                .symbol(CatSymbol.builder().id(1L).symbol("ES").build())
+                .tickValue(12.5)
+                .commission(2.0)
+                .build();
+
+        BdMarketRepository repo = Mockito.mock(BdMarketRepository.class);
+        Mockito.when(repo.findOneByMktAccMdata(1L,1L,1L))
+                .thenReturn(List.of(bd));
+
+        OptimizationService svc = new OptimizationService(repo);
+
+        RiskInputDTO base = RiskInputDTO.builder()
+                .account(bd.getAccount())
+                .market(bd.getMarket())
+                .marketData(bd.getMarketData())
+                .accountSize(new BigDecimal("200"))
+                .riskReward(2.0)
+                .ticksSl1(1)
+                .ticksSl2(1)
+                .lunch(true)
+                .firstTrade(false)
+                .riskPctB(new BigDecimal("1.5"))
+                .build();
+
+        // WIN → highlight second row (k=1)
+        List<ResultRowDTO> winRows = svc.calculate(base.toBuilder().win(true).build());
+        assertEquals(2, winRows.size());
+        assertTrue(winRows.get(1).getOptimalRow().get());
+        assertFalse(winRows.get(0).getOptimalRow().get());
+
+        // LOSS → highlight first row (k=0)
+        List<ResultRowDTO> lossRows = svc.calculate(base.toBuilder().win(false).build());
+        assertEquals(2, lossRows.size());
+        assertTrue(lossRows.get(0).getOptimalRow().get());
+        assertFalse(lossRows.get(1).getOptimalRow().get());
+    }
 }
 


### PR DESCRIPTION
## Summary
- Subrayar en la tabla de resultados el escenario de riesgo efectivo, destacando `base + x` tras una victoria y el escenario base tras una pérdida.
- Añadir pruebas unitarias que verifican el subrayado correcto según el resultado del trade.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5485da45c832dacbbf9be8790cdfb