### PR TITLE
Add edit/delete actions to risk dashboard table

### DIFF
--- a/src/main/java/com/cwdarmm/controller/MarketRiskDashboardController.java
+++ b/src/main/java/com/cwdarmm/controller/MarketRiskDashboardController.java
@@ -7,6 +7,7 @@ package com.cwdarmm.controller;
 
 import com.cwdarmm.config.SpringFXMLLoader;
 import com.cwdarmm.model.dto.MarketDTO;
+import com.cwdarmm.model.dto.RiskInputDTO;
 import com.cwdarmm.model.dto.RiskResultDTO;
 import com.cwdarmm.service.OutputService;
 import javafx.beans.property.ReadOnlyObjectWrapper;
@@ -14,9 +15,11 @@ import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
+import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.scene.layout.HBox;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +28,10 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.file.Path;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.ResourceBundle;
 
 @Component
@@ -42,12 +48,14 @@ public class MarketRiskDashboardController {
     @FXML private TableColumn<RiskResultDTO, BigDecimal>  colAccountSize;
     @FXML private TableColumn<RiskResultDTO,Double>  colRiskA;
     @FXML private TableColumn<RiskResultDTO,Double>  colRiskB;
+    @FXML private TableColumn<RiskResultDTO, Void>   colActions;
     @FXML private Button btnExportCsv;
     @FXML private ResourceBundle resources;
 
     private final OutputService outputService;
     private final SpringFXMLLoader springFXMLLoader;
     private MarketDTO context;
+    private final Map<RiskResultDTO, RiskInputDTO> requestByResult = new IdentityHashMap<>();
 
     public void setContext(MarketDTO context) {
         this.context = context;
@@ -62,6 +70,7 @@ public class MarketRiskDashboardController {
                 .riskKellyB(context.getRiskB())
                 .build());
         tableResults.setItems(FXCollections.observableArrayList(initial));
+        requestByResult.clear();
     }
 
     @FXML
@@ -118,6 +127,111 @@ public class MarketRiskDashboardController {
                         .showAndWait();
             }
         });
+
+        initActionsColumn();
+    }
+
+    private void initActionsColumn() {
+        colActions.setCellFactory(col -> new TableCell<>() {
+            private final Button btnEdit = new Button("✎");
+            private final Button btnDelete = new Button("✖");
+            private final HBox pane = new HBox(5, btnEdit, btnDelete);
+
+            {
+                pane.setAlignment(Pos.CENTER);
+                btnEdit.setOnAction(e -> {
+                    RiskResultDTO dto = getTableView().getItems().get(getIndex());
+                    onEditResult(dto);
+                });
+                btnDelete.setOnAction(e -> {
+                    RiskResultDTO dto = getTableView().getItems().get(getIndex());
+                    onDeleteResult(dto);
+                });
+            }
+
+            @Override
+            protected void updateItem(Void item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || getTableRow() == null || getIndex() < 0) {
+                    setGraphic(null);
+                } else {
+                    RiskResultDTO dto = getTableView().getItems().get(getIndex());
+                    btnEdit.setDisable(!requestByResult.containsKey(dto));
+                    setGraphic(pane);
+                }
+            }
+        });
+    }
+
+    private void onEditResult(RiskResultDTO dto) {
+        RiskInputDTO baseRequest = requestByResult.get(dto);
+        if (baseRequest == null) {
+            new Alert(Alert.AlertType.INFORMATION,
+                    resources.getString("risk.dashboard.edit.unavailable"))
+                    .showAndWait();
+            return;
+        }
+
+        try {
+            FXMLLoader loader = springFXMLLoader.load("/fxml/RiskConfigForm.fxml");
+            RiskConfigController formCtrl = loader.getController();
+
+            Stage dialog = new Stage();
+            dialog.initOwner(tableResults.getScene().getWindow());
+            dialog.initModality(Modality.APPLICATION_MODAL);
+            dialog.setTitle(context.getMarket().getDescription() + " – "
+                    + resources.getString("risk.dashboard.edit.window"));
+            dialog.setScene(new Scene(loader.getRoot()));
+
+            formCtrl.setDialogStage(dialog);
+            formCtrl.setMarketContext(context);
+            formCtrl.setInitialRequest(baseRequest);
+            formCtrl.setOnCalculated((req, rows) -> {
+                if (req.isFirstTrade()) {
+                    tableResults.getItems().setAll(rows);
+                    requestByResult.clear();
+                    rows.forEach(r -> requestByResult.put(r, req.toBuilder().build()));
+                } else if (!rows.isEmpty()) {
+                    RiskResultDTO calculated = rows.get(rows.size() - 1);
+                    applyResultValues(dto, calculated);
+                    requestByResult.put(dto, req.toBuilder().build());
+                }
+
+                if (req.getRiskPctA() != null) {
+                    context.setRiskA(req.getRiskPctA().doubleValue());
+                }
+                if (req.getRiskPctB() != null) {
+                    context.setRiskB(req.getRiskPctB().doubleValue());
+                }
+
+                tableResults.refresh();
+            });
+
+            dialog.showAndWait();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void onDeleteResult(RiskResultDTO dto) {
+        Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
+                resources.getString("risk.dashboard.delete.confirm"),
+                ButtonType.YES, ButtonType.NO);
+        Optional<ButtonType> answer = confirm.showAndWait();
+        if (answer.orElse(ButtonType.NO) == ButtonType.YES) {
+            tableResults.getItems().remove(dto);
+            requestByResult.remove(dto);
+            tableResults.refresh();
+        }
+    }
+
+    private void applyResultValues(RiskResultDTO target, RiskResultDTO source) {
+        target.setWl(source.getWl());
+        target.setAccount(source.getAccount());
+        target.setMarketData(source.getMarketData());
+        target.setAccountSize(source.getAccountSize());
+        target.setRiskKellyA(source.getRiskKellyA());
+        target.setRiskKellyB(source.getRiskKellyB());
     }
 
     @FXML
@@ -136,9 +250,11 @@ public class MarketRiskDashboardController {
             if (req.isFirstTrade()) {
                 // primer trade: limpiamos y mostramos sólo INITIAL
                 items.clear();
+                requestByResult.clear();
             }
             // tanto si es primer trade como posterior, añadimos las filas calculadas
             items.addAll(rows);
+            rows.forEach(r -> requestByResult.put(r, req.toBuilder().build()));
 
             if (req.getRiskPctA() != null) {
                 context.setRiskA(req.getRiskPctA().doubleValue());
@@ -146,6 +262,8 @@ public class MarketRiskDashboardController {
             if (req.getRiskPctB() != null) {
                 context.setRiskB(req.getRiskPctB().doubleValue());
             }
+
+            tableResults.refresh();
         });
         dialog.initOwner(tableResults.getScene().getWindow());
         dialog.initModality(Modality.APPLICATION_MODAL);

--- a/src/main/java/com/cwdarmm/controller/RiskConfigController.java
+++ b/src/main/java/com/cwdarmm/controller/RiskConfigController.java
@@ -128,6 +128,42 @@ public class RiskConfigController {
     }
 
 
+    public void setInitialRequest(RiskInputDTO request) {
+        if (request == null) {
+            return;
+        }
+
+        if (request.getAccount() != null) {
+            cbRiskAccount.setValue(request.getAccount());
+        }
+        if (request.getMarket() != null) {
+            cbRiskMarket.setValue(request.getMarket());
+        }
+        if (request.getMarketData() != null) {
+            cbRiskMarketData.setDisable(false);
+            cbRiskMarketData.setValue(request.getMarketData());
+        }
+
+        tfRiskAccountSize.setText(request.getAccountSize() == null
+                ? ""
+                : request.getAccountSize().toPlainString());
+        tfRiskReward.setText(String.valueOf(request.getRiskReward()));
+        tfTicksSl1.setText(request.getTicksSl1() == null ? "" : request.getTicksSl1().toString());
+        tfTicksSl2.setText(request.getTicksSl2() == null ? "" : request.getTicksSl2().toString());
+        tfStopLossSize.setText(request.getStopLossSize() == 0
+                ? ""
+                : Integer.toString(request.getStopLossSize()));
+
+        chkHouse.setSelected(request.isHouse());
+        chkLunch.setSelected(request.isLunch());
+        chkWin.setSelected(request.isWin());
+        chkLoss.setSelected(request.isLoss());
+
+        this.pctHouse = request.getRiskPctA();
+        this.pctLunch = request.getRiskPctB();
+    }
+
+
     /** Para compatibilidad con viejos callers que usaban Runnable */
     public void setOnCalculated(Runnable callback) {
         this.onCalculated = (dto, rows) -> callback.run();

--- a/src/main/resources/fxml/MarketRiskDashboard.fxml
+++ b/src/main/resources/fxml/MarketRiskDashboard.fxml
@@ -29,6 +29,7 @@
                 <TableColumn fx:id="colAccountSize" text="%risk.dashboard.accountsize"/>
                 <TableColumn fx:id="colRiskA"    text="%risk.dashboard.riska"/>
                 <TableColumn fx:id="colRiskB"    text="%risk.dashboard.riskb"/>
+                <TableColumn fx:id="colActions"  text="%risk.dashboard.actions" prefWidth="100"/>
             </columns>
         </TableView>
     </center>

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -99,9 +99,13 @@ risk.dashboard.marketdata=Market Data
 risk.dashboard.accountsize=Account Size
 risk.dashboard.riska=Risk Kelly A
 risk.dashboard.riskb=Risk Kelly B
+risk.dashboard.actions=Actions
 risk.dashboard.export=Export CSV
 risk.dashboard.close=Close
 risk.dashboard.window=Risk Manager
+risk.dashboard.edit.window=Edit risk entry
+risk.dashboard.delete.confirm=Do you want to delete this risk entry?
+risk.dashboard.edit.unavailable=This entry cannot be edited because it does not have associated risk parameters yet.
 
 # Optimal Contracts
 optimal.contracts.slsize=SL Size (Ticks)

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -99,9 +99,13 @@ risk.dashboard.marketdata=Datos de Mercado
 risk.dashboard.accountsize=Tamaño de Cuenta
 risk.dashboard.riska=Riesgo Kelly A
 risk.dashboard.riskb=Riesgo Kelly B
+risk.dashboard.actions=Acciones
 risk.dashboard.export=Exportar CSV
 risk.dashboard.close=Cerrar
 risk.dashboard.window=Gestor de Riesgo
+risk.dashboard.edit.window=Editar registro de riesgo
+risk.dashboard.delete.confirm=¿Deseas eliminar este registro de riesgo?
+risk.dashboard.edit.unavailable=No es posible editar este registro porque aún no tiene parámetros de riesgo asociados.
 
 # Optimal Contracts
 optimal.contracts.slsize=Tamaño SL (Ticks)


### PR DESCRIPTION
## Summary
- add an actions column to the risk dashboard table with edit and delete controls
- reuse the risk configuration dialog to edit existing entries and keep the context in sync
- extend the risk configuration controller and translations to prefill dialogs for editing

## Testing
- mvn -q -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_690047583fac832db89362279dc7b796